### PR TITLE
[OS-925, OS-958] Forcing to use CMake 3.10.0 to run the tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
+#
+# Main CMake file
+#
+
+# Minimum CMake version required to build the software
 cmake_minimum_required(VERSION 3.7.2 FATAL_ERROR)
+
 project(Mercury VERSION 0.1)
 
 set(CMAKE_CXX_STANDARD 11)
@@ -7,9 +13,6 @@ include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
 add_subdirectory(src)
-
-# FIXME: Find out how to accomodate the tests build on the PI,
-# there are problems due to the CMake version.
-#add_subdirectory(test)
+add_subdirectory(test)
 
 enable_testing()

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 BUILD_DIR := build
+CONAN_PROFILE=../conan-platforms/conan-profile-$(shell uname -m).info
 COVERAGE_DIR := coverage
 COVERAGE_INFO := ${COVERAGE_DIR}/coverage.info
 COVERAGE_EXCLUDES := \
@@ -17,7 +18,7 @@ all: build
 
 build:
 	mkdir -p build
-	cd build && conan install --build=missing ..
+	cd build && conan install --build=missing --profile=${CONAN_PROFILE} ..
 	cd build && cmake ..
 	cd build && make
 

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,8 @@ Build
 
 `CMake <https://cmake.org/documentation/>`_ (3.10.0 minimum to allow us to use some of the newer goodies) is used to build both the project and the tests.
 
+If your linux system is based on Debian Stretch, you can use the `backports <https://backports.debian.org/Instructions/>`_ repositories to pull the latest CMake version. Alternatively, you can point your APT sources to Debian Buster.
+
 
 Test
 -----

--- a/conan-platforms/conan-profile-armv7l.info
+++ b/conan-platforms/conan-profile-armv7l.info
@@ -1,0 +1,12 @@
+[settings]
+os=Linux
+os_build=Linux
+arch=armv7hf
+arch_build=armv7hf
+compiler=gcc
+compiler.version=6
+compiler.libcxx=libstdc++11
+build_type=Release
+[options]
+[build_requires]
+[env]

--- a/conan-platforms/conan-profile-x86_64.info
+++ b/conan-platforms/conan-profile-x86_64.info
@@ -1,0 +1,12 @@
+[settings]
+os=Linux
+os_build=Linux
+arch=x86_64
+arch_build=x86_64
+compiler=gcc
+compiler.version=6
+compiler.libcxx=libstdc++11
+build_type=Release
+[options]
+[build_requires]
+[env]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,11 +8,9 @@ target_compile_options(mercury
 	PRIVATE -fprofile-arcs -ftest-coverage
 )
 
-# option below is available starting with cmake 3.13
-# cmake on the pi is v3.7.2
-#target_link_options(mercury
-#	PRIVATE -coverage
-#)
+target_link_options(mercury
+	PRIVATE -coverage
+)
 
 target_include_directories(mercury PUBLIC
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/../include>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,7 +12,7 @@ else()
 
     target_link_libraries(mercury_gtests
       PUBLIC mercury
-      PRIVATE GTest::GTest GTest::Main CONAN_PKG::gtest
+      PRIVATE GTest::Main GTest::GTest CONAN_PKG::gtest
       )
 
     target_compile_options(mercury_gtests
@@ -20,7 +20,7 @@ else()
       )
 
     target_link_options(mercury_gtests
-      PRIVATE -coverage -rpath ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+      PRIVATE -coverage -Wl,-rpath,${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
       )
 
     enable_testing()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(${CMAKE_VERSION} VERSION_LESS "3.10.0")
+  message("WARNING: You need CMake version 3.10.0 or above in order to run tests")
+else()
+
 find_package(GTest)
 include(GoogleTest)
 
@@ -15,7 +19,6 @@ target_compile_options(mercury_gtests
     PRIVATE -fprofile-arcs -ftest-coverage
 )
 
-# again, option not available on cmake version on the pi
 target_link_options(mercury_gtests
     PRIVATE -coverage -rpath ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
 )
@@ -23,3 +26,5 @@ target_link_options(mercury_gtests
 
 enable_testing()
 gtest_discover_tests(mercury_gtests)
+
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,30 +1,29 @@
 if(${CMAKE_VERSION} VERSION_LESS "3.10.0")
+
   message("WARNING: You need CMake version 3.10.0 or above in order to run tests")
+
 else()
 
-find_package(GTest)
-include(GoogleTest)
+    find_package(GTest)
+    include(GoogleTest)
+    add_executable(mercury_gtests
+      test.cpp
+      )
 
+    target_link_libraries(mercury_gtests
+      PUBLIC mercury
+      PRIVATE GTest::GTest GTest::Main CONAN_PKG::gtest
+      )
 
-add_executable(mercury_gtests
-    test.cpp
-)
+    target_compile_options(mercury_gtests
+      PRIVATE -fprofile-arcs -ftest-coverage
+      )
 
-target_link_libraries(mercury_gtests
-    PUBLIC mercury
-    PRIVATE GTest::GTest GTest::Main CONAN_PKG::gtest
-)
+    target_link_options(mercury_gtests
+      PRIVATE -coverage -rpath ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+      )
 
-target_compile_options(mercury_gtests
-    PRIVATE -fprofile-arcs -ftest-coverage
-)
-
-target_link_options(mercury_gtests
-    PRIVATE -coverage -rpath ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
-)
-
-
-enable_testing()
-gtest_discover_tests(mercury_gtests)
+    enable_testing()
+    gtest_discover_tests(mercury_gtests)
 
 endif()


### PR DESCRIPTION
Due to too many options missing on previous CMake versions, we are resolving this issue by forcing the use of CMake version 3.10.0 or above.

Tested on a xsysroot Kano image with latest CMake, it now builds fine.
