### PR TITLE
[OS-932] Re-enable tests for debuild packaging process

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,11 +3,17 @@ Maintainer: Team Kano <dev@kano.me>
 Section: tools
 Priority: optional
 Standards-Version: 1.1.0
-Build-Depends: debhelper(>= 9.0.0), build-essential, cmake, python-conan, lcov
+Build-Depends: debhelper(>= 9.0.0),
+               build-essential,
+               cmake,
+               python-conan,
+               lcov
 
 Package: mercury
 Architecture: any
-Depends: libc6, libstdc++6, libgcc1
+Depends: libc6,
+         libstdc++6,
+         libgcc1
 Description: Kano OS multiplatform API abstraction layer
 
 Package: mercury-dev

--- a/debian/rules
+++ b/debian/rules
@@ -2,6 +2,3 @@
 
 %:
 	dh $@
-
-override_dh_auto_test:
-	echo "FIXME: We need to fix gtest build for the RPi to run dh_auto_test"


### PR DESCRIPTION
This changeset re-enables the tests to be run during the package build process `debuild`.
If all tests pass, the package is generated.
I tested it on a xsysroot sandbox and installed the package afterwards, it all seems to run smoothly.
