### PR TITLE
[OS-932] - Matching gcc version for Debian Buster

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,3 +6,12 @@ import build_deb_pkg
 stage ('Build') {
     autobuild_repo_pkg 'mercury'
 }
+
+stage ('Test') {
+    def test_repos = [
+        "mercury"
+        ]
+
+    ubuntu_make_test(test_repos) {
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,6 @@ stage ('Test') {
         "mercury"
         ]
 
-    ubuntu_make_test(test_repos) {
+    make_test(test_repos, "make test") {
     }
 }

--- a/conan-platforms/conan-profile-x86_64.info
+++ b/conan-platforms/conan-profile-x86_64.info
@@ -4,7 +4,7 @@ os_build=Linux
 arch=x86_64
 arch_build=x86_64
 compiler=gcc
-compiler.version=6
+compiler.version=8
 compiler.libcxx=libstdc++11
 build_type=Release
 [options]


### PR DESCRIPTION
This PR is a companion to the Docker definition here:

 * https://github.com/KanoComputing/docker-mercury-builder

Since we are using a Debian Buster Docker for x86_64, to run the tests, this changeset simply matches the expected gcc version.

I have tested to run the Mercury tests with `make test` on a fresh instance, it takes less than 6secs !
