### PR TITLE
[OS-948] Urgent fix for unresolved symbol on the RPi

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,10 +9,10 @@ target_compile_options(mercury
 )
 
 if(${CMAKE_VERSION} VERSION_LESS "3.10.0")
-    set (CMAKE_LINKER_FLAGS "PRIVATE -coverage")
+    set (CMAKE_LINKER_FLAGS "PRIVATE -coverage -lgcov")
 else()
     target_link_options(mercury
-        PRIVATE -coverage
+        PRIVATE -coverage -lgcov
         )
 endif()
 


### PR DESCRIPTION
This PR fixes a subtle but critical issue on the mercury library loading on the RPi.
`Unresolved symbol: __gcov_merge_add`. Adding the library during link time fixes the problem.
Confirmed that all python tests pass now on the RPi after this fix.
