### PR TITLE
Fix docs build by creating a build dir

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,6 +17,7 @@ help:
 
 all:
 	# Generate the reST files from which the documentation will be built.
+	mkdir -p build/doxygen
 	doxygen doxygen.conf
 	sphinx-apidoc -o source/ ../
 	$(MAKE) html


### PR DESCRIPTION
Error:
```
radu@Radus-MacBook-Pro:~/Kano/mercury$ make docs
cd docs && make all
# Generate the reST files from which the documentation will be built.
doxygen doxygen.conf
error: tag OUTPUT_DIRECTORY: Output directory `build/doxygen' does not exist and cannot be created
Exiting...
make[1]: *** [all] Error 1
make: *** [docs] Error 2
```