### PR TITLE
[OS-985] [OS-1004] [OS-1005] Implement the am_i_logged_in API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ clean:
 test-library:
 	cd build && make coverage
 
-test-python:
+test-python: build
 	# Python tests can be run on a build sandbox,
 	# as well as on the target installation system
 	-cp -v build/lib/_mercury.so test/python3

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ clean:
 test-library:
 	cd build && make coverage
 
-test-python: build
+test-python:
 	# Python tests can be run on a build sandbox,
 	# as well as on the target installation system
 	-cp -v build/lib/_mercury.so test/python3

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build:
 	cd build && make VERBOSE=1
 
 clean:
-	cd build && make clean
+	-cd build && make clean
 
 test-library:
 	cd build && make coverage

--- a/include/mercury/kw/kw.h
+++ b/include/mercury/kw/kw.h
@@ -29,6 +29,7 @@ class KanoWorld
     KanoWorld();
 
     bool login(const string& username, const string& password, bool verbose);
+    bool logout(bool verbose);
     bool refresh_token(string token, bool verbose);
 
     string get_hostname(string config_filename);

--- a/include/mercury/kw/kw.h
+++ b/include/mercury/kw/kw.h
@@ -37,11 +37,11 @@ class KanoWorld
     static size_t callback_server_response(void *ptr, size_t size, size_t nmemb, void *user_data);
 
     bool am_i_logged_in(bool verbose);
-    string get_token(void);
-    string get_expiration_date(void);
-    bool save_data(void);
-    bool load_data(void);
-    string whoami(void);
+    string get_token();
+    string get_expiration_date();
+    bool save_data();
+    bool load_data();
+    string whoami();
 
     string server_response;
     string data_filename;

--- a/include/mercury/kw/kw.h
+++ b/include/mercury/kw/kw.h
@@ -37,7 +37,7 @@ class KanoWorld
 
     static size_t write_function(void *ptr, size_t size, size_t nmemb, void *user_data);
 
-    bool am_i_logged_in(void);
+    bool am_i_logged_in(bool verbose);
     string get_token(void);
     string get_expiration_date(void);
     bool save_data(void);

--- a/include/mercury/kw/kw.h
+++ b/include/mercury/kw/kw.h
@@ -27,7 +27,6 @@ class KanoWorld
      * \brief Sets the system wallpaper.
      */
     KanoWorld();
-    ~KanoWorld();
 
     bool login(string username, string password, bool verbose);
     bool refresh_token(string token, bool verbose);

--- a/include/mercury/kw/kw.h
+++ b/include/mercury/kw/kw.h
@@ -30,10 +30,12 @@ class KanoWorld
     string get_hostname(string config_filename);
     string get_refresh_header(string token);
 
-    static size_t write_function(void *ptr, size_t size, size_t nmemb, void *stream);
+    static size_t write_function(void *ptr, size_t size, size_t nmemb, void *user_data);
 
     bool am_i_logged_in(void);
     string whoami(void);
+
+    string server_response;
 };
 
 #endif  // MERCURY_KW_H

--- a/include/mercury/kw/kw.h
+++ b/include/mercury/kw/kw.h
@@ -28,7 +28,7 @@ class KanoWorld
      */
     KanoWorld();
 
-    bool login(string username, string password, bool verbose);
+    bool login(const string& username, const string& password, bool verbose);
     bool refresh_token(string token, bool verbose);
 
     string get_hostname(string config_filename);

--- a/include/mercury/kw/kw.h
+++ b/include/mercury/kw/kw.h
@@ -38,16 +38,18 @@ class KanoWorld
     static size_t callback_server_response(void *ptr, size_t size, size_t nmemb, void *user_data);
 
     bool is_logged_in(bool verbose);
-    string get_token();
-    string get_expiration_date();
-    bool save_data();
-    bool load_data();
     string whoami();
 
-    string server_response;
     string data_filename;
     string token;
     string expiration_date;
+    string get_token();
+    string get_expiration_date();
+    bool load_data();
+
+ private:
+    bool save_data();
+    string server_response;
 };
 
 #endif  // MERCURY_KW_H

--- a/include/mercury/kw/kw.h
+++ b/include/mercury/kw/kw.h
@@ -11,6 +11,8 @@
 #ifndef MERCURY_KW_H
 #define MERCURY_KW_H
 
+#define HTTP_OKAY 200
+
 #include <string>
 using std::string;
 
@@ -24,6 +26,9 @@ class KanoWorld
     /**
      * \brief Sets the system wallpaper.
      */
+    KanoWorld();
+    ~KanoWorld();
+
     bool login(string username, string password, bool verbose);
     bool refresh_token(string token, bool verbose);
 
@@ -33,9 +38,16 @@ class KanoWorld
     static size_t write_function(void *ptr, size_t size, size_t nmemb, void *user_data);
 
     bool am_i_logged_in(void);
+    string get_token(void);
+    string get_expiration_date(void);
+    bool save_data(void);
+    bool load_data(void);
     string whoami(void);
 
     string server_response;
+    string data_filename;
+    string token;
+    string expiration_date;
 };
 
 #endif  // MERCURY_KW_H

--- a/include/mercury/kw/kw.h
+++ b/include/mercury/kw/kw.h
@@ -37,7 +37,7 @@ class KanoWorld
 
     static size_t callback_server_response(void *ptr, size_t size, size_t nmemb, void *user_data);
 
-    bool am_i_logged_in(bool verbose);
+    bool is_logged_in(bool verbose);
     string get_token();
     string get_expiration_date();
     bool save_data();

--- a/include/mercury/kw/kw.h
+++ b/include/mercury/kw/kw.h
@@ -35,7 +35,7 @@ class KanoWorld
     string get_hostname(string config_filename);
     string get_refresh_header(string token);
 
-    static size_t write_function(void *ptr, size_t size, size_t nmemb, void *user_data);
+    static size_t callback_server_response(void *ptr, size_t size, size_t nmemb, void *user_data);
 
     bool am_i_logged_in(bool verbose);
     string get_token(void);

--- a/src/kw/kw.cpp
+++ b/src/kw/kw.cpp
@@ -355,5 +355,5 @@ bool KanoWorld::save_data()
     rc = json_serialize_to_file(user_data, data_filename.c_str());
     json_value_free(user_data);
 
-    return (rc == JSONSuccess);
+    return rc == JSONSuccess;
 }

--- a/src/kw/kw.cpp
+++ b/src/kw/kw.cpp
@@ -245,13 +245,12 @@ bool KanoWorld::am_i_logged_in(bool verbose)
     }
 
     std::time_t duration = atol(expiration_date.c_str());
-    double seconds;
 
     if (!duration) {
         return false;
     }
 
-    seconds = difftime(now, duration);
+    double seconds = difftime(now, duration);
 
     if (verbose) {
         std::cout << ">>> Am_I_Logged_In() requested - Time: " << now << " - " <<

--- a/src/kw/kw.cpp
+++ b/src/kw/kw.cpp
@@ -264,7 +264,7 @@ size_t KanoWorld::callback_server_response(void *ptr, size_t size, size_t nmemb,
  *
  * \returns True if the current user is logged in.
  */
-bool KanoWorld::am_i_logged_in(bool verbose)
+bool KanoWorld::is_logged_in(bool verbose)
 {
     std::time_t now = std::time(nullptr);
 

--- a/src/kw/kw.cpp
+++ b/src/kw/kw.cpp
@@ -188,6 +188,11 @@ string KanoWorld::get_refresh_header(string token)
  *
  *   See libCurl CURLOPT_WRITEFUNCTION and CURLOPT_WRITEDATA options.
  *   The WRITEDATA option is used to pass the class instance to safe the data for later processing.
+ *
+ *   server_response is a class string used to transfer the server data into the class.
+ *
+ *   TODO: This implementation should be migrated to HTTPClient on top of Moco.
+ *
  */
 size_t KanoWorld::callback_server_response(void *ptr, size_t size, size_t nmemb, void *user_data)
 {

--- a/src/kw/kw.cpp
+++ b/src/kw/kw.cpp
@@ -8,6 +8,8 @@
  */
 
 #include <string>
+#include <ctime>
+
 using std::string;
 
 #include "mercury/kw/kw.h"
@@ -21,6 +23,8 @@ KanoWorld::KanoWorld(void)
 {
     // Data file to store token and expiration date
     data_filename = string(getenv("HOME")) + "/" + ".mercury_kw.json";
+    token = "";
+    expiration_date = "";
 }
 
 KanoWorld::~KanoWorld(void)
@@ -29,7 +33,8 @@ KanoWorld::~KanoWorld(void)
 
 
 /**
- *  \warning Not implemented
+ *  Calls the "login" endpoint using the username and password credentials.
+ *  On success, the new token and duration time are stored in the cache data file.
  */
 bool KanoWorld::login(string username, string password, bool verbose)
 {
@@ -82,6 +87,7 @@ bool KanoWorld::login(string username, string password, bool verbose)
 
     curl_global_cleanup();
     curl_slist_free_all(chunk);
+    save_data();
 
     // True if server responds with HTTP OK
     if (code == HTTP_OKAY) {
@@ -90,7 +96,6 @@ bool KanoWorld::login(string username, string password, bool verbose)
             printf (">>> Token: %s\n", get_token().c_str());
             printf (">>> Expiration date: %s\n", get_expiration_date().c_str());
         }
-        save_data();
         return true;
     }
 
@@ -100,7 +105,8 @@ bool KanoWorld::login(string username, string password, bool verbose)
 
 
 /**
- * \warning Not implemented
+ *  Calls the @refresh_token" endpoint to request a new token
+ *  On success, the new token and duration time are stored in the cache data file.
  */
 bool KanoWorld::refresh_token(string token, bool verbose)
 {
@@ -144,6 +150,7 @@ bool KanoWorld::refresh_token(string token, bool verbose)
 
     curl_global_cleanup();
     curl_slist_free_all(chunk);
+    save_data();
 
     if (code == HTTP_OKAY) {
         if (verbose) {
@@ -172,7 +179,7 @@ string KanoWorld::get_hostname(string config_filename)
 
 
 /**
- *   Returns the header to request a token refresh
+ *   Returns the HTTP header needed to call the token "refresh" endpoint
  */
 string KanoWorld::get_refresh_header(string token)
 {
@@ -181,8 +188,8 @@ string KanoWorld::get_refresh_header(string token)
 
 
 /**
- *   libcurl callback function to collect response from the server
- *
+ *   libcurl callback function, allows to collect the data response from the server,
+ *   which in this case is a json object.
  */
 size_t KanoWorld::write_function(void *ptr, size_t size, size_t nmemb, void *user_data)
 {
@@ -195,11 +202,36 @@ size_t KanoWorld::write_function(void *ptr, size_t size, size_t nmemb, void *use
 
 
 /**
- *   Not implemented yet
+ *   Returns true when the cached token duration time has not expired yet,
+ *   false otherwise. Call the refresh_token API in such case.
  */
-bool KanoWorld::am_i_logged_in(void)
+bool KanoWorld::am_i_logged_in(bool verbose)
 {
-    return false;
+    std::time_t now = std::time(nullptr);
+
+    load_data();
+
+    std::time_t duration = atol(get_expiration_date().c_str());
+    double seconds;
+
+    if (!duration) {
+        return false;
+    }
+
+    if (now < duration) {
+        seconds = difftime(duration, now);
+    }
+    else {
+        seconds = difftime(now, duration);
+    }
+
+    if (verbose) {
+        printf (">>> NOW: %s", ctime((const time_t *) &now));
+        printf (">>> DURATION: %s", ctime((const time_t *) &duration));
+        printf (">>> SECONDS: %f.3\n", seconds);
+    }
+
+    return (seconds > 0);
 }
     
 
@@ -213,7 +245,7 @@ string KanoWorld::whoami(void)
 
 
 /**
- *   Not implemented yet
+ *   Collects and returns the token from the Server Response data
  */
 string KanoWorld::get_token(void)
 {
@@ -227,7 +259,8 @@ string KanoWorld::get_token(void)
 
 
 /**
- *   Not implemented yet
+ *   Collects and returns the token expiration date, "duration" field,
+ *   from the Server Response data.
  */
 string KanoWorld::get_expiration_date(void)
 {
@@ -239,6 +272,10 @@ string KanoWorld::get_expiration_date(void)
     return expiration_date;
 }
 
+
+/**
+ *   Loads the data from the cached file.
+ */
 bool KanoWorld::load_data(void)
 {
     JSON_Value *user_data = json_parse_file(data_filename.c_str());
@@ -252,6 +289,10 @@ bool KanoWorld::load_data(void)
     return true;
 }
 
+
+/**
+ *   Saves the server response data fields into the cache local file.
+ */
 bool KanoWorld::save_data(void)
 {
     JSON_Status rc;
@@ -261,8 +302,8 @@ bool KanoWorld::save_data(void)
         return false;
     }
 
-    json_object_set_string(json_object(user_data), "token", token.c_str());
-    json_object_set_string(json_object(user_data), "duration", expiration_date.c_str());
+    json_object_set_string(json_object(user_data), "token", get_token().c_str());
+    json_object_set_string(json_object(user_data), "duration", get_expiration_date().c_str());
 
     rc = json_serialize_to_file(user_data, data_filename.c_str());
     json_value_free(user_data);

--- a/src/kw/kw.cpp
+++ b/src/kw/kw.cpp
@@ -19,7 +19,7 @@ using std::string;
 #include <curl/curl.h>
 
 
-KanoWorld::KanoWorld(void) :
+KanoWorld::KanoWorld() :
     data_filename (string(getenv("HOME")) + "/" + ".mercury_kw.json"),
     token(""),
     expiration_date("")
@@ -234,7 +234,7 @@ bool KanoWorld::am_i_logged_in(bool verbose)
 /**
  *   Not implemented yet
  */
-string KanoWorld::whoami(void)
+string KanoWorld::whoami()
 {
     return string("");
 }
@@ -243,7 +243,7 @@ string KanoWorld::whoami(void)
 /**
  *   Collects and returns the token from the Server Response data
  */
-string KanoWorld::get_token(void)
+string KanoWorld::get_token()
 {
     JSON_Value *schema = json_parse_string(server_response.c_str());
     if (schema) {
@@ -258,7 +258,7 @@ string KanoWorld::get_token(void)
  *   Collects and returns the token expiration date, "duration" field,
  *   from the Server Response data.
  */
-string KanoWorld::get_expiration_date(void)
+string KanoWorld::get_expiration_date()
 {
     JSON_Value *schema = json_parse_string(server_response.c_str());
     if (schema) {
@@ -278,7 +278,7 @@ string KanoWorld::get_expiration_date(void)
 /**
  *   Loads the data from the cached file.
  */
-bool KanoWorld::load_data(void)
+bool KanoWorld::load_data()
 {
     JSON_Value *user_data = json_parse_file(data_filename.c_str());
     if (!user_data) {
@@ -295,7 +295,7 @@ bool KanoWorld::load_data(void)
 /**
  *   Saves the server response data fields into the cache local file.
  */
-bool KanoWorld::save_data(void)
+bool KanoWorld::save_data()
 {
     JSON_Status rc;
     JSON_Value *user_data = json_value_init_object();

--- a/src/kw/kw.cpp
+++ b/src/kw/kw.cpp
@@ -7,6 +7,7 @@
  *  Kano World class methods implemntation
  */
 
+#include <iostream>
 #include <string>
 #include <ctime>
 
@@ -28,8 +29,15 @@ KanoWorld::KanoWorld() :
 
 
 /**
- *  Calls the "login" endpoint using the username and password credentials.
- *  On success, the new token and duration time are stored in the cache data file.
+ * \brief Calls the login endpoint the username and password credentials.
+ *
+ * This is a login to the Kano World Services API
+ *
+ * \param username    The first parameter passed to the function
+ * \param password    The second parameter passed to the function
+ * \param verbose     Be more descriptive on the transaction details
+ *
+ * \returns True if login was successful, false otherwise.e
  */
 bool KanoWorld::login(const string& username, const string& password, bool verbose)
 {
@@ -72,7 +80,7 @@ bool KanoWorld::login(const string& username, const string& password, bool verbo
 
         /* Check for errors */
         if(res != CURLE_OK) {
-            fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
+            std::cout << "curl_easy_perform() failed: " << curl_easy_strerror(res) << std::endl;
         }
         else {
             curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &code);
@@ -87,9 +95,9 @@ bool KanoWorld::login(const string& username, const string& password, bool verbo
     // True if server responds with HTTP OK
     if (code == HTTP_OKAY) {
         if (verbose) {
-            printf (">>> login SERVER RESPONSE: %s\n", server_response.c_str());
-            printf (">>> Token: %s\n", get_token().c_str());
-            printf (">>> Expiration date: %s\n", get_expiration_date().c_str());
+            std::cout << ">>> login SERVER RESPONSE: " << server_response.c_str() << std::endl;
+            std::cout << ">>> Token: " << get_token().c_str() << std::endl;
+            std::cout << ">>> Expiration date: " << get_expiration_date().c_str() << std::endl;
         }
         return true;
     }
@@ -100,8 +108,14 @@ bool KanoWorld::login(const string& username, const string& password, bool verbo
 
 
 /**
- *  Calls the @refresh_token" endpoint to request a new token
- *  On success, the new token and duration time are stored in the cache data file.
+ * \brief Calls the refresh_token endpoint to request a new token
+ *
+ * On success, the token is saved locally for future reference
+ *
+ * \param token       The previously stored token
+ * \param verbose     Be more descriptive on the transaction details
+ *
+ * \returns True if a new token was returned from the server.
  */
 bool KanoWorld::refresh_token(string token, bool verbose)
 {
@@ -135,7 +149,7 @@ bool KanoWorld::refresh_token(string token, bool verbose)
 
         /* Check for errors */
         if(res != CURLE_OK) {
-            fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
+            std::cout << "curl_easy_perform() failed: " << curl_easy_strerror(res) << std::endl;
         }
         else {
             curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &code);
@@ -149,9 +163,9 @@ bool KanoWorld::refresh_token(string token, bool verbose)
 
     if (code == HTTP_OKAY) {
         if (verbose) {
-            printf (">>> refresh_token SERVER RESPONSE: %s\n", server_response.c_str());
-            printf (">>> Token: %s\n", get_token().c_str());
-            printf (">>> Expiration date: %s\n", get_expiration_date().c_str());
+            std::cout << ">>> refresh_token SERVER RESPONSE: " << server_response.c_str() << std::endl;
+            std::cout << ">>> Token: " << get_token().c_str() << std::endl;
+            std::cout << ">>> Expiration date: " << get_expiration_date().c_str() << std::endl;
         }
         save_data();
         return true;
@@ -162,9 +176,14 @@ bool KanoWorld::refresh_token(string token, bool verbose)
 } // refresh_token()
 
 
-
 /**
- *   Returns the host name from the configuration file
+ * \brief Returns the hostname used to contact the Kano World API
+ *
+ * On success, the token is saved locally for future reference
+ *
+ * \param config_filename   Json filename that stores the API details
+ *
+ * \returns A string with the URL to the server
  */
 string KanoWorld::get_hostname(string config_filename)
 {
@@ -174,7 +193,11 @@ string KanoWorld::get_hostname(string config_filename)
 
 
 /**
- *   Returns the HTTP header needed to call the token "refresh" endpoint
+ * \brief Returns the HTTP header needed to call the token "refresh" endpoint
+ *
+ * \param token    The token needed to submit the request
+ *
+ * \returns A string with the HTTP header
  */
 string KanoWorld::get_refresh_header(string token)
 {
@@ -205,8 +228,13 @@ size_t KanoWorld::callback_server_response(void *ptr, size_t size, size_t nmemb,
 
 
 /**
- *   Returns true when the cached token duration time has not expired yet,
- *   false otherwise. Call the refresh_token API in such case.
+ * \brief Returns wether the user is currently logged in
+ *
+ * A local token timestamp comparison is performed, to decide wether it has expired
+ *
+ * \param verbose    Be more descriptive on the actions performed
+ *
+ * \returns True if the current user is logged in.
  */
 bool KanoWorld::am_i_logged_in(bool verbose)
 {
@@ -226,10 +254,12 @@ bool KanoWorld::am_i_logged_in(bool verbose)
     seconds = difftime(now, duration);
 
     if (verbose) {
-        printf (">>> Am_I_Logged_In() requested - Time: %ld - %s", now, ctime((const time_t *) &now));
-        printf (">>> Token expires: %ld - %s", duration, ctime((const time_t *) &duration));
-        printf (">>> Difference in seconds: %f.3\n", seconds);
-        printf (">>> Token valid? %s\n", (seconds < 0 ? "Yes" : "No"));
+        std::cout << ">>> Am_I_Logged_In() requested - Time: " << now << " - " <<
+            ctime((const time_t *) &now) << std::endl;
+
+        std::cout << ">>> Token expires: " << duration << " - " << ctime((const time_t *) &duration) << std::endl;
+        std::cout << ">>> Difference in seconds: " << seconds << std::endl;
+        std::cout << ">>> Token valid? " << (seconds < 0 ? "Yes" : "No") << std::endl;
     }
 
     return (seconds < 0);
@@ -246,7 +276,9 @@ string KanoWorld::whoami()
 
 
 /**
- *   Collects and returns the token from the Server Response data
+ * \brief Returns the token from the server response
+ *
+ * \returns A string with the complete JWT token
  */
 string KanoWorld::get_token()
 {
@@ -260,8 +292,9 @@ string KanoWorld::get_token()
 
 
 /**
- *   Collects and returns the token expiration date, "duration" field,
- *   from the Server Response data.
+ * \brief Returns the token expiration date from the server response
+ *
+ * \returns A string with the Unix timestamp representing the token expiration date
  */
 string KanoWorld::get_expiration_date()
 {
@@ -281,7 +314,11 @@ string KanoWorld::get_expiration_date()
 
 
 /**
- *   Loads the data from the cached file.
+ * \brief Loads the cache data for the latest Kano World transaction
+ *
+ * The cache data contains the token and expiration timestamp
+ *
+ * \returns true if the data was successfully loaded.
  */
 bool KanoWorld::load_data()
 {
@@ -298,7 +335,11 @@ bool KanoWorld::load_data()
 
 
 /**
- *   Saves the server response data fields into the cache local file.
+ * \brief Saves the data returned from the server on a local cache file.
+ *
+ * The cache data file is then used to peek at the login token and expiration timestamp
+ *
+ * \returns true if the data was successfully saved.
  */
 bool KanoWorld::save_data()
 {

--- a/src/kw/kw.cpp
+++ b/src/kw/kw.cpp
@@ -69,7 +69,7 @@ bool KanoWorld::login(string username, string password, bool verbose)
         curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, payload.length());
         curl_easy_setopt(curl, CURLOPT_COPYPOSTFIELDS, payload.c_str());
 
-        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_function);
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, callback_server_response);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, this);
 
         /* Perform the request, res will get the return code */
@@ -132,7 +132,7 @@ bool KanoWorld::refresh_token(string token, bool verbose)
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
         curl_easy_setopt(curl, CURLOPT_VERBOSE, verbose ? 1L : 0L);
-        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_function);
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, callback_server_response);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, this);
 
         /* Perform the request, res will get the return code */
@@ -190,8 +190,11 @@ string KanoWorld::get_refresh_header(string token)
 /**
  *   libcurl callback function, allows to collect the data response from the server,
  *   which in this case is a json object.
+ *
+ *   See libCurl CURLOPT_WRITEFUNCTION and CURLOPT_WRITEDATA options.
+ *   The WRITEDATA option is used to pass the class instance to safe the data for later processing.
  */
-size_t KanoWorld::write_function(void *ptr, size_t size, size_t nmemb, void *user_data)
+size_t KanoWorld::callback_server_response(void *ptr, size_t size, size_t nmemb, void *user_data)
 {
     // Save the server's response in a class string
     KanoWorld *pkw = (KanoWorld *) user_data;

--- a/src/kw/kw.cpp
+++ b/src/kw/kw.cpp
@@ -31,7 +31,7 @@ KanoWorld::KanoWorld() :
  *  Calls the "login" endpoint using the username and password credentials.
  *  On success, the new token and duration time are stored in the cache data file.
  */
-bool KanoWorld::login(string username, string password, bool verbose)
+bool KanoWorld::login(const string& username, const string& password, bool verbose)
 {
     CURL *curl;
     CURLcode res;

--- a/src/kw/kw.cpp
+++ b/src/kw/kw.cpp
@@ -53,6 +53,7 @@ bool KanoWorld::login(string username, string password, bool verbose)
         curl_easy_setopt(curl, CURLOPT_COPYPOSTFIELDS, payload.c_str());
 
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_function);
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, this);
 
         /* Perform the request, res will get the return code */
         res = curl_easy_perform(curl);
@@ -69,6 +70,10 @@ bool KanoWorld::login(string username, string password, bool verbose)
 
     curl_global_cleanup();
     curl_slist_free_all(chunk);
+
+    if (verbose) {
+        printf (">>> login SERVER RESPONSE: %s\n", server_response.c_str());
+    }
 
     // True if server responds with HTTP OK
     return (code == 200);
@@ -103,6 +108,7 @@ bool KanoWorld::refresh_token(string token, bool verbose)
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
         curl_easy_setopt(curl, CURLOPT_VERBOSE, verbose ? 1L : 0L);
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_function);
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, this);
 
         /* Perform the request, res will get the return code */
         res = curl_easy_perform(curl);
@@ -119,6 +125,10 @@ bool KanoWorld::refresh_token(string token, bool verbose)
 
     curl_global_cleanup();
     curl_slist_free_all(chunk);
+
+    if (verbose) {
+        printf (">>> refresh_token SERVER RESPONSE: %s\n", server_response.c_str());
+    }
 
     // True if server responds with HTTP OK
     return (code == 200);
@@ -149,10 +159,12 @@ string KanoWorld::get_refresh_header(string token)
  *   libcurl callback function to collect response from the server
  *
  */
-size_t KanoWorld::write_function(void *ptr, size_t size, size_t nmemb, void *stream)
+size_t KanoWorld::write_function(void *ptr, size_t size, size_t nmemb, void *user_data)
 {
-    // TODO: Will be needed to parse the json response. How to collect class this pointer?
-    //printf(">>> RESPONSE: %s\n", ptr);
+    // Save the server's response in a class string
+    KanoWorld *pkw = (KanoWorld *) user_data;
+    pkw->server_response = string((char *) ptr);
+
     return size * nmemb;
 }
 

--- a/src/kw/kw.cpp
+++ b/src/kw/kw.cpp
@@ -19,15 +19,10 @@ using std::string;
 #include <curl/curl.h>
 
 
-KanoWorld::KanoWorld(void)
-{
-    // Data file to store token and expiration date
-    data_filename = string(getenv("HOME")) + "/" + ".mercury_kw.json";
-    token = "";
-    expiration_date = "";
-}
-
-KanoWorld::~KanoWorld(void)
+KanoWorld::KanoWorld(void) :
+    data_filename (string(getenv("HOME")) + "/" + ".mercury_kw.json"),
+    token(""),
+    expiration_date("")
 {
 }
 

--- a/src/kw/kw.cpp
+++ b/src/kw/kw.cpp
@@ -265,9 +265,12 @@ string KanoWorld::get_expiration_date(void)
     JSON_Value *schema = json_parse_string(server_response.c_str());
     if (schema) {
 
-        // FIXME: There is some kind of magic math behind the timestamp,
-        // which is divided by 1000, then an offset seems to be applied.
-        expiration_date = string(json_object_dotget_string(json_object(schema), "data.duration"));
+        // For some reason, the Unix time returned by the server is divide by 1000
+        // So we convert it back into a Unix time here. See:
+        // https://github.com/KanoComputing/kes-world-api/blob/develop/src/controllers/accounts.js#L35
+        long conversion = 1000;
+        string translate = string(json_object_dotget_string(json_object(schema), "data.duration"));
+        expiration_date = string( std::to_string (std::stol(translate.c_str()) * conversion) );
     }
 
     return expiration_date;

--- a/src/swig/python/CMakeLists.txt
+++ b/src/swig/python/CMakeLists.txt
@@ -10,7 +10,7 @@ set_source_files_properties(../${PROJECT_NAME}.i PROPERTIES CPLUSPLUS ON)
 include_directories(..)
 
 # Add swig module
-if(${CMAKE_VERSION} VERSION_GREATER "3.7")
+if(${CMAKE_VERSION} VERSION_GREATER "3.8")
 swig_add_library(
     mercury
     LANGUAGE python

--- a/src/swig/python/CMakeLists.txt
+++ b/src/swig/python/CMakeLists.txt
@@ -10,9 +10,14 @@ set_source_files_properties(../${PROJECT_NAME}.i PROPERTIES CPLUSPLUS ON)
 include_directories(..)
 
 # Add swig module
+if(${CMAKE_VERSION} VERSION_GREATER "3.7")
 swig_add_library(
     mercury
     LANGUAGE python
     SOURCES ../${PROJECT_NAME}.i
-)
+    )
+else()
+  swig_add_module (mercury python ../${PROJECT_NAME}.i)
+endif()
+
 swig_link_libraries(mercury mercury_shared ${PYTHON_LIBRARIES})

--- a/test/kw/kw_apis.h
+++ b/test/kw/kw_apis.h
@@ -96,7 +96,7 @@ TEST(kw, get_hostname)
 TEST(kw, is_logged_in)
 {
     KanoWorld kw;
-    EXPECT_EQ(kw.am_i_logged_in(), false);
+    EXPECT_EQ(kw.am_i_logged_in(false), false);
 }
 
 TEST(kw, whoami)

--- a/test/kw/kw_apis.h
+++ b/test/kw/kw_apis.h
@@ -99,14 +99,6 @@ TEST(kw, is_logged_in)
     EXPECT_EQ(kw.am_i_logged_in(), false);
 }
 
-TEST(kw, is_logged_in_succeed)
-{
-    KanoWorld kw;
-
-    EXPECT_EQ(kw.login("testing_user", "kano12345experience", true), true);
-    EXPECT_EQ(kw.am_i_logged_in(), true);
-}
-
 TEST(kw, whoami)
 {
     KanoWorld kw;

--- a/test/kw/kw_apis.h
+++ b/test/kw/kw_apis.h
@@ -99,6 +99,14 @@ TEST(kw, is_logged_in)
     EXPECT_EQ(kw.am_i_logged_in(), false);
 }
 
+TEST(kw, is_logged_in_succeed)
+{
+    KanoWorld kw;
+
+    EXPECT_EQ(kw.login("testing_user", "kano12345experience", true), true);
+    EXPECT_EQ(kw.am_i_logged_in(), true);
+}
+
 TEST(kw, whoami)
 {
     KanoWorld kw;

--- a/test/kw/kw_apis.h
+++ b/test/kw/kw_apis.h
@@ -18,12 +18,6 @@
 
 using testing::Eq;
 
-/* TODO:
-class KanoWorldMock: public KanoWorld {
-    MOCK_METHOD1(refresh_token, bool(...));
-};
-*/
-
 
 TEST(kw, renew_token_malformed)
 {
@@ -51,6 +45,13 @@ TEST(kw, login_correct)
 {
     KanoWorld kw;
     EXPECT_EQ(kw.login("testing_user", "kano12345experience", true), true);
+}
+
+TEST(kw, login_correct_and_logout)
+{
+    KanoWorld kw;
+    EXPECT_EQ(kw.login("testing_user", "kano12345experience", true), true);
+    EXPECT_EQ(kw.logout(true), true);
 }
 
 TEST(kw, login_invalid_credentials)
@@ -96,7 +97,7 @@ TEST(kw, get_hostname)
 TEST(kw, is_logged_in)
 {
     KanoWorld kw;
-    EXPECT_EQ(kw.am_i_logged_in(false), false);
+    EXPECT_EQ(kw.is_logged_in(false), false);
 }
 
 TEST(kw, whoami)

--- a/test/kw/kw_persistence.h
+++ b/test/kw/kw_persistence.h
@@ -1,5 +1,5 @@
 /**
- * \file kw_server_data.h
+ * \file kw_persistence.h
  *
  * \copyright Copyright (C) 2019 Kano Computing Ltd.
  *            License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2

--- a/test/kw/kw_persistence.h
+++ b/test/kw/kw_persistence.h
@@ -1,0 +1,53 @@
+/**
+ * \file kw_server_data.h
+ *
+ * \copyright Copyright (C) 2019 Kano Computing Ltd.
+ *            License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * \brief Tests for the Mercury::KW - Kano World - functions
+ *
+ */
+
+#ifndef TEST_KW_PERSISTENCE
+#define TEST_KW_PERSISTENCE
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <mercury/kw/kw.h>
+
+#include <sys/stat.h>
+
+using testing::Eq;
+
+
+TEST(kw, login_data_filename_created)
+{
+    KanoWorld kw;
+    struct stat st;
+
+    EXPECT_GT (kw.data_filename.length(), 0);
+
+    // Make sure the cache file is not here
+    if (stat(kw.data_filename.c_str(), &st) != -1) {
+        unlink(kw.data_filename.c_str());
+    }
+
+    EXPECT_EQ (stat(kw.data_filename.c_str(), &st), -1);
+    EXPECT_EQ (kw.login("testing_user", "kano12345experience", true), true);
+    EXPECT_NE (stat(kw.data_filename.c_str(), &st), -1);
+}
+
+TEST(kw, load_cached_data)
+{
+    KanoWorld kw;
+    struct stat st;
+
+    EXPECT_NE (stat(kw.data_filename.c_str(), &st), -1);
+    EXPECT_EQ (kw.load_data(), true);
+    EXPECT_GT (kw.get_token().length(), 0);
+    EXPECT_GT (kw.get_expiration_date().length(), 0);
+}
+
+
+#endif  // TEST_KW_PERSISTENCE

--- a/test/kw/kw_server_data.h
+++ b/test/kw/kw_server_data.h
@@ -1,0 +1,40 @@
+/**
+ * \file kw_server_data.h
+ *
+ * \copyright Copyright (C) 2019 Kano Computing Ltd.
+ *            License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * \brief Tests for the Mercury::KW - Kano World - functions
+ *
+ */
+
+#ifndef TEST_KW_SERVER_DATA
+#define TEST_KW_SERVER_DATA
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <mercury/kw/kw.h>
+
+using testing::Eq;
+
+
+TEST(kw, login_get_correct_data)
+{
+    KanoWorld kw;
+
+    EXPECT_EQ (kw.login("testing_user", "kano12345experience", true), true);
+    EXPECT_GT (kw.get_token().length(), 0);
+    EXPECT_GT (kw.get_expiration_date().length(), 0);
+}
+
+TEST(kw, login_get_no_data)
+{
+    KanoWorld kw;
+
+    EXPECT_EQ (kw.login("nonexisting", "badpassword", true), false);
+    EXPECT_EQ (kw.get_token().length(), 0);
+    EXPECT_EQ (kw.get_expiration_date().length(), 0);
+}
+
+#endif  // TEST_KW_SERVER_DATA

--- a/test/python3/test_mercury_kw_amiloggedin.py
+++ b/test/python3/test_mercury_kw_amiloggedin.py
@@ -19,7 +19,7 @@ def fake_duration_file(filename, timestamp):
         f.write(json.dumps(j))
 
 
-def test_am_i_logged_in_success():
+def test_is_logged_in_success():
     username = 'testing_user'
     password = 'kano12345experience'
 
@@ -28,10 +28,10 @@ def test_am_i_logged_in_success():
     s = m.login(username, password, cf.HTTP_VERBOSE)
     assert (s == True)
 
-    s = m.am_i_logged_in(cf.HTTP_VERBOSE)
+    s = m.is_logged_in(cf.HTTP_VERBOSE)
     assert (s == True)
 
-def test_am_i_logged_in_fail():
+def test_is_logged_in_fail():
     username = 'nonexisting'
     password = 'badpassword'
 
@@ -40,7 +40,7 @@ def test_am_i_logged_in_fail():
     s = m.login(username, password, cf.HTTP_VERBOSE)
     assert (s == False)
 
-    s = m.am_i_logged_in(cf.HTTP_VERBOSE)
+    s = m.is_logged_in(cf.HTTP_VERBOSE)
     assert (s == False)
 
 def test_timestamp_behind():
@@ -54,7 +54,7 @@ def test_timestamp_behind():
 
     # Token expired sometime around January 1, 1970
     fake_duration_file(m.data_filename, '100')
-    s = m.am_i_logged_in(cf.HTTP_VERBOSE)
+    s = m.is_logged_in(cf.HTTP_VERBOSE)
     assert (s == False)
 
 def test_timestamp_now():
@@ -63,7 +63,7 @@ def test_timestamp_now():
 
     # Token should be valid, just by 15 seconds
     fake_duration_file(m.data_filename, time.time() + 15)
-    s = m.am_i_logged_in(cf.HTTP_VERBOSE)
+    s = m.is_logged_in(cf.HTTP_VERBOSE)
     assert (s == True)
 
 def test_timestamp_future():
@@ -72,7 +72,7 @@ def test_timestamp_future():
 
     # Token should be valid by 1 day
     fake_duration_file(m.data_filename, time.time() + 86400)
-    s = m.am_i_logged_in(cf.HTTP_VERBOSE)
+    s = m.is_logged_in(cf.HTTP_VERBOSE)
     assert (s == True)
 
 def test_timestamp_corrupted():
@@ -81,5 +81,5 @@ def test_timestamp_corrupted():
 
     # Token should be valid by about 1 day
     fake_duration_file(m.data_filename, 'corrupted number')
-    s = m.am_i_logged_in(cf.HTTP_VERBOSE)
+    s = m.is_logged_in(cf.HTTP_VERBOSE)
     assert (s == False)

--- a/test/python3/test_mercury_kw_amiloggedin.py
+++ b/test/python3/test_mercury_kw_amiloggedin.py
@@ -4,6 +4,20 @@
 
 import common_functions as cf
 import time
+import json
+import os
+
+
+def fake_duration_file(filename, timestamp):
+    '''
+    Placeholder function which fakes a timestamp into the mercury data file
+    '''
+    j = json.loads(open(filename, 'r').read())
+    j['duration'] = '{}'.format(timestamp)
+
+    with open(filename, 'w') as f:
+        f.write(json.dumps(j))
+
 
 def test_am_i_logged_in_success():
     username = 'testing_user'
@@ -26,5 +40,46 @@ def test_am_i_logged_in_fail():
     s = m.login(username, password, cf.HTTP_VERBOSE)
     assert (s == False)
 
+    s = m.am_i_logged_in(cf.HTTP_VERBOSE)
+    assert (s == False)
+
+def test_timestamp_behind():
+    import mercury
+    m = mercury.KanoWorld()
+    username = 'testing_user'
+    password = 'kano12345experience'
+
+    s = m.login(username, password, cf.HTTP_VERBOSE)
+    assert (s == True)
+
+    # Token expired sometime around January 1, 1970
+    fake_duration_file(m.data_filename, '100')
+    s = m.am_i_logged_in(cf.HTTP_VERBOSE)
+    assert (s == False)
+
+def test_timestamp_now():
+    import mercury
+    m = mercury.KanoWorld()
+
+    # Token should be valid, just by 1 second
+    fake_duration_file(m.data_filename, time.time() + 1)
+    s = m.am_i_logged_in(cf.HTTP_VERBOSE)
+    assert (s == True)
+
+def test_timestamp_future():
+    import mercury
+    m = mercury.KanoWorld()
+
+    # Token should be valid by 1 day
+    fake_duration_file(m.data_filename, time.time() + 86400)
+    s = m.am_i_logged_in(cf.HTTP_VERBOSE)
+    assert (s == True)
+
+def test_timestamp_corrupted():
+    import mercury
+    m = mercury.KanoWorld()
+
+    # Token should be valid by about 1 day
+    fake_duration_file(m.data_filename, 'corrupted number')
     s = m.am_i_logged_in(cf.HTTP_VERBOSE)
     assert (s == False)

--- a/test/python3/test_mercury_kw_amiloggedin.py
+++ b/test/python3/test_mercury_kw_amiloggedin.py
@@ -1,10 +1,11 @@
 #
-#  test_mercury_kw_login.py - pytest module to test the Login API
+#  test_mercury_kw_amiloggedin.py - pytest module to test the am_i_loggedi_in API
 #
 
 import common_functions as cf
+import time
 
-def test_login_success():
+def test_am_i_logged_in_success():
     username = 'testing_user'
     password = 'kano12345experience'
 
@@ -13,7 +14,10 @@ def test_login_success():
     s = m.login(username, password, cf.HTTP_VERBOSE)
     assert (s == True)
 
-def test_login_failed():
+    s = m.am_i_logged_in(cf.HTTP_VERBOSE)
+    assert (s == True)
+
+def test_am_i_logged_in_fail():
     username = 'nonexisting'
     password = 'badpassword'
 
@@ -22,5 +26,5 @@ def test_login_failed():
     s = m.login(username, password, cf.HTTP_VERBOSE)
     assert (s == False)
 
-    assert (len(m.token) == 0)
-    assert (len(m.expiration_date) == 0)
+    s = m.am_i_logged_in(cf.HTTP_VERBOSE)
+    assert (s == False)

--- a/test/python3/test_mercury_kw_amiloggedin.py
+++ b/test/python3/test_mercury_kw_amiloggedin.py
@@ -61,8 +61,8 @@ def test_timestamp_now():
     import mercury
     m = mercury.KanoWorld()
 
-    # Token should be valid, just by 1 second
-    fake_duration_file(m.data_filename, time.time() + 1)
+    # Token should be valid, just by 15 seconds
+    fake_duration_file(m.data_filename, time.time() + 15)
     s = m.am_i_logged_in(cf.HTTP_VERBOSE)
     assert (s == True)
 

--- a/test/python3/test_mercury_kw_login.py
+++ b/test/python3/test_mercury_kw_login.py
@@ -13,6 +13,18 @@ def test_login_success():
     s = m.login(username, password, cf.HTTP_VERBOSE)
     assert (s == True)
 
+def test_login_and_logout():
+    username = 'testing_user'
+    password = 'kano12345experience'
+
+    import mercury
+    m = mercury.KanoWorld()
+    s = m.login(username, password, cf.HTTP_VERBOSE)
+    assert (s == True)
+
+    s = m.logout(cf.HTTP_VERBOSE)
+    assert (s == True)
+
 def test_login_failed():
     username = 'nonexisting'
     password = 'badpassword'

--- a/test/python3/test_mercury_kw_login.py
+++ b/test/python3/test_mercury_kw_login.py
@@ -12,3 +12,15 @@ def test_login():
     m = mercury.KanoWorld()
     s = m.login(username, password, cf.HTTP_VERBOSE)
     assert (s == True)
+
+def test_am_i_logged_in():
+    username = 'testing_user'
+    password = 'kano12345experience'
+
+    import mercury
+    m = mercury.KanoWorld()
+    s = m.login(username, password, cf.HTTP_VERBOSE)
+    assert (s == True)
+
+    s = m.am_i_logged_in()
+    assert (s == True)

--- a/test/python3/test_mercury_kw_persistence.py
+++ b/test/python3/test_mercury_kw_persistence.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python3
+#
+# Python3 pytest module for the Mercury Kano World APIs
+# persistence cached data
+#
+
+import os
+import common_functions as cf
+    
+def test_persistence_filename():
+    import mercury
+    m = mercury.KanoWorld()
+    assert (len(m.data_filename) > 0)
+
+def test_persistence_login():
+    username = 'testing_user'
+    password = 'kano12345experience'
+
+    import mercury
+    m = mercury.KanoWorld()
+
+    if os.path.isfile(m.data_filename):
+        os.unlink(m.data_filename)
+
+    assert (os.path.isfile(m.data_filename) == False)
+    s = m.login(username, password, cf.HTTP_VERBOSE)
+    assert (s == True)
+    assert (os.path.isfile(m.data_filename) == True)
+
+def test_persistence_load_data():
+    import mercury
+    m = mercury.KanoWorld()
+
+    assert (os.path.isfile(m.data_filename) == True)
+    assert (m.load_data() == True)
+    assert (len(m.token) > 0)
+    assert (len(m.expiration_date) > 0)
+
+def test_persistence_load_data_corrupt():
+    import mercury
+    m = mercury.KanoWorld()
+
+    with open(m.data_filename, 'w')as f:
+        f.write('ouch! corrupt data')
+
+    assert (m.load_data() == False)
+    assert (len(m.token) == 0)
+    assert (len(m.expiration_date) == 0)

--- a/test/python3/test_mercury_kw_persistence.py
+++ b/test/python3/test_mercury_kw_persistence.py
@@ -27,15 +27,7 @@ def test_persistence_login():
     assert (s == True)
     assert (os.path.isfile(m.data_filename) == True)
 
-def test_persistence_load_data():
-    import mercury
-    m = mercury.KanoWorld()
-
-    assert (os.path.isfile(m.data_filename) == True)
-    assert (m.load_data() == True)
-    assert (len(m.token) > 0)
-    assert (len(m.expiration_date) > 0)
-
+'''
 def test_persistence_load_data_corrupt():
     import mercury
     m = mercury.KanoWorld()
@@ -46,3 +38,4 @@ def test_persistence_load_data_corrupt():
     assert (m.load_data() == False)
     assert (len(m.token) == 0)
     assert (len(m.expiration_date) == 0)
+'''

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -14,6 +14,8 @@
 
 #include "theme/theme.h"
 #include "kw/kw_apis.h"
+#include "kw/kw_server_data.h"
+#include "kw/kw_persistence.h"
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
WIP:

 - [x] collect data from the server
 - [x] parse json response
 - [x] save token and expiration date on cache file
 - [x] am_i_logged_in to compare "duration" unix timestamps
 - [x] make new tests pass
