### PR TITLE
HTTP: Add simple HTTP interface and client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 coverage
+docs/make.bat
+docs/source/index.xml
 
 # Created by https://www.gitignore.io/api/vim,osx,c++,linux,cmake,emacs,python,windows,sublimetext,visualstudiocode
 # Edit at https://www.gitignore.io/?templates=vim,osx,c++,linux,cmake,emacs,python,windows,sublimetext,visualstudiocode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,10 @@ conan_basic_setup(TARGETS)
 
 add_subdirectory(src)
 
-if(${CMAKE_VERSION} VERSION_GREATER "3.10.0")
-    add_subdirectory(test)
-endif()
+if (CMAKE_BUILD_TYPE MATCHES Debug)
+    if (${CMAKE_VERSION} VERSION_GREATER "3.10.0")
+        add_subdirectory(test)
+    endif ()
+endif (CMAKE_BUILD_TYPE MATCHES Debug)
 
 enable_testing()

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -2,6 +2,7 @@ set noparent
 linelength=80
 
 exclude_files=build
+exclude_files=cmake
 
 filter=+build/class,
 filter=+build/c++11,

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ build:
 clean:
 	cd build && make clean
 
-test-library:
-	cd build && make coverage
+test-library: build
+	cd build && CTEST_OUTPUT_ON_FAILURE=1 make coverage
 
 test-python:
 	# Python tests can be run on a build sandbox,

--- a/Makefile
+++ b/Makefile
@@ -1,41 +1,40 @@
 BUILD_DIR := build
-CONAN_PROFILE=../conan-platforms/conan-profile-$(shell uname -s)-$(shell uname -m).info
-COVERAGE_DIR := coverage
-COVERAGE_INFO := ${COVERAGE_DIR}/coverage.info
-COVERAGE_EXCLUDES := \
-	"*Qt*.framework*" \
-	"*.h" \
-	"*/tests/*" \
-	"*.moc" \
-	"*moc_*.cpp" \
-	"*/test/*" \
-	"*/build*/*" \
-	"*Xcode.app*"
+RELEASE :=
+CONAN_PROFILE=../../conan-platforms/conan-profile-$(shell uname -s)-$(shell uname -m).info
 
 .PHONY: build lint clean test docs
 
-all: build
+all: build-release
 
-build:
-	mkdir -p build
-	cd build && conan install --build=missing --profile=${CONAN_PROFILE} ..
-	cd build && cmake ..
-	cd build && make VERBOSE=1
+_build:
+	mkdir -p build/$(RELEASE)
+	cd build/$(RELEASE) && conan install --build=missing --profile=${CONAN_PROFILE} ../..
+	cd build/$(RELEASE) && cmake -DCMAKE_BUILD_TYPE=$(RELEASE) ../..
+	cd build/$(RELEASE) && make VERBOSE=1
+
+build-debug: RELEASE=Debug
+build-debug: _build
+
+build-release: RELEASE=Release
+build-release: _build
+
+build: build-release
 
 clean:
-	cd build && make clean
+	cd build/Release && make clean
+	cd build/Debug && make clean
 
-test-library: build
-	cd build && CTEST_OUTPUT_ON_FAILURE=1 make coverage
+test-library: build-debug
+	cd build/Debug && CTEST_OUTPUT_ON_FAILURE=1 make coverage
 
-test-python:
+test-python: build-debug
 	# Python tests can be run on a build sandbox,
 	# as well as on the target installation system
-	-cp -v build/lib/_mercury.so test/python3
+	-cp -v build/Debug/lib/_mercury.so test/python3
 	-cp -v build/src/swig/python/mercury.py test/python3
 	cd test/python3 && python3 -m pytest $(TESTMODULE)
 
-test: build test-library test-python
+test: build-debug test-library test-python
 
 check: test
 

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -2,6 +2,7 @@
 gtest/1.8.1@bincrafters/stable
 libcurl/7.64.1@bincrafters/stable
 parson/0.1.0@bincrafters/stable
+Poco/1.9.2@pocoproject/stable
 
 [generators]
 cmake

--- a/debian/mercury.install
+++ b/debian/mercury.install
@@ -1,1 +1,1 @@
-build/lib/libmercury.so /usr/lib
+build/Release/lib/libmercury.so /usr/lib

--- a/debian/python-mercury.install
+++ b/debian/python-mercury.install
@@ -1,2 +1,2 @@
 build/src/swig/python/mercury.py /usr/lib/python3/dist-packages
-build/lib/_mercury.so /usr/lib/python3/dist-packages
+build/Release/lib/_mercury.so /usr/lib/python3/dist-packages

--- a/docs/doxygen.conf
+++ b/docs/doxygen.conf
@@ -814,7 +814,8 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = ../src \
-                         ../include
+                         ../include \
+                         ../test
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/docs/source/http.rst
+++ b/docs/source/http.rst
@@ -1,0 +1,55 @@
+HTTP
+================
+
+Interfaces
+----------------
+
+.. doxygeninterface:: IHTTPClient
+   :project: mercury
+   :members:
+   :protected-members:
+   :private-members:
+   :undoc-members:
+
+Implementations
+----------------
+
+.. doxygenclass:: HTTPClient
+   :project: mercury
+   :members:
+   :protected-members:
+   :private-members:
+   :undoc-members:
+
+.. doxygenclass:: MockHTTPClient
+   :project: mercury
+   :members:
+   :protected-members:
+   :private-members:
+   :undoc-members:
+
+Exceptions
+----------------
+
+.. doxygenclass:: HTTPClientError
+   :project: mercury
+   :members:
+   :protected-members:
+   :private-members:
+   :undoc-members:
+
+
+.. doxygenclass:: SessionInitError
+   :project: mercury
+   :members:
+   :protected-members:
+   :private-members:
+   :undoc-members:
+
+
+.. doxygenclass:: HTTPRequestFailedError
+   :project: mercury
+   :members:
+   :protected-members:
+   :private-members:
+   :undoc-members:

--- a/docs/source/kano_world.rst
+++ b/docs/source/kano_world.rst
@@ -1,0 +1,9 @@
+KanoWorld
+================
+
+.. doxygenclass:: KanoWorld
+   :project: mercury
+   :members:
+   :protected-members:
+   :private-members:
+   :undoc-members:

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -5,6 +5,8 @@ Mercury
 .. toctree::
    :maxdepth: 4
 
+   http
+   kano_world
    theme
 
 .. doxygenindex::

--- a/include/mercury/_http/exceptions.h
+++ b/include/mercury/_http/exceptions.h
@@ -1,0 +1,63 @@
+/**
+ * \file exceptions.cpp
+ *
+ * \copyright Copyright (C) 2019 Kano Computing Ltd.
+ *            License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ */
+
+
+#ifndef MERCURY__HTTP_EXCEPTIONS_H_
+#define MERCURY__HTTP_EXCEPTIONS_H_
+
+
+#include <exception>
+#include <map>
+#include <string>
+
+
+/**
+ * \class HTTPClientError
+ * \brief Base exception to throw when there is an error with the HTTPClient
+ */
+class HTTPClientError : public std::exception {
+ public:
+    explicit HTTPClientError(const std::string msg) : message(msg) {}
+    const std::string message;
+    const char *what() const noexcept(true) {
+        return this->message.c_str();
+    }
+};
+
+
+/**
+ * \class SessionInitError
+ * \brief Exception to throw when there is an error initialising the HTTP
+ *        session
+ */
+class SessionInitError : public HTTPClientError {
+ public:
+    explicit SessionInitError(const std::string msg) :
+        HTTPClientError(
+            std::string("Initialising HTTP session failed: ") + msg
+        ) {}
+};
+
+
+/**
+ * \class HTTPRequestFailedError
+ * \brief Exception to throw when there is an error with the HTTP request
+ */
+class HTTPRequestFailedError : public HTTPClientError {
+ public:
+    HTTPRequestFailedError(const int err_no, const std::string reason) :
+        HTTPClientError(
+            std::string("HTTP request failed. Status code: ") +
+            std::to_string(err_no) +
+            std::string(" (") + reason + std::string(")")),
+        error_code(err_no) {}
+    const int error_code;
+};
+
+
+#endif  // MERCURY__HTTP_EXCEPTIONS_H_

--- a/include/mercury/_http/http_client.h
+++ b/include/mercury/_http/http_client.h
@@ -1,0 +1,69 @@
+/**
+ * \file http_client.h
+ *
+ * \copyright Copyright (C) 2019 Kano Computing Ltd.
+ *            License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * \brief     HTTP request client
+ *
+ */
+
+
+#ifndef MERCURY__HTTP_HTTP_CLIENT_H_
+#define MERCURY__HTTP_HTTP_CLIENT_H_
+
+
+#include <parson.h>
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "mercury/_http/http_client_interface.h"
+
+
+/**
+ * \class HTTPClient
+ * \brief Simple implementation of IHTTPClient
+ */
+class HTTPClient : public IHTTPClient {
+ public:
+    HTTPClient();
+    std::shared_ptr<JSON_Value> POST(
+        const std::string& url,
+        const std::string& body,
+        const std::map<std::string, std::string>& headers =
+            std::map<std::string, std::string>()) override;
+    std::shared_ptr<JSON_Value> POST(
+        const std::string& url,
+        const std::shared_ptr<JSON_Value> body,
+        const std::map<std::string, std::string>& headers =
+            std::map<std::string, std::string>()) override;
+    std::shared_ptr<JSON_Value> GET(
+        const std::string& url,
+        const std::map<std::string, std::string>& headers =
+            std::map<std::string, std::string>()) override;
+
+ protected:
+    /**
+     * \brief Builds and sends a request to a server
+     *
+     * \param method    The HTTP method to use (One of HTTPRequest::HTTP_GET,
+     *                  HTTPRequest::HTTP_POST)
+     * \param url       The URL to POST
+     * \param headers   (Optional) Headers to pass to add to the request
+     * \param body      (Optional) The body of the request
+     *
+     * \throws SessionInitError          Unable to initialise the session
+     * \throws HTTPRequestFailedError    Server response wasn't OK (!= 200)
+     */
+    std::shared_ptr<JSON_Value> send_request(
+        const std::string& method,
+        const std::string& url,
+        const std::map<std::string, std::string>& headers =
+            std::map<std::string, std::string>(),
+        const std::string& body = "");
+};
+
+
+#endif  // MERCURY__HTTP_HTTP_CLIENT_H_

--- a/include/mercury/_http/http_client_interface.h
+++ b/include/mercury/_http/http_client_interface.h
@@ -1,0 +1,85 @@
+/**
+ * \file http_client_interface.cpp
+ *
+ * \copyright Copyright (C) 2019 Kano Computing Ltd.
+ *            License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ */
+
+#ifndef MERCURY__HTTP_HTTP_CLIENT_INTERFACE_H_
+#define MERCURY__HTTP_HTTP_CLIENT_INTERFACE_H_
+
+
+#include <parson.h>
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "mercury/_http/exceptions.h"
+
+
+/**
+ * \interface IHTTPClient
+ * \brief Interface for an HTTP client
+ */
+class IHTTPClient {
+ public:
+     /**
+      * \brief Explicitly define a virtual destructor so that classes that
+      *        implement this don't have issues
+      */
+    virtual ~IHTTPClient() {}
+    /**
+     * \brief POSTs data to a server
+     *
+     * \param url       The URL to POST
+     * \param body      The body of the request
+     * \param headers   (Optional) Headers to pass to add to the request
+     *
+     * \throws SessionInitError          Unable to initialise the session
+     * \throws HTTPRequestFailedError    Server response wasn't OK (!= 200)
+     *
+     * \returns    The data returned from the server
+     */
+    virtual std::shared_ptr<JSON_Value> POST(
+        const std::string& url,
+        const std::string& body,
+        const std::map<std::string, std::string>& headers =
+            std::map<std::string, std::string>()) = 0;
+    /**
+     * \brief POSTs data to a server
+     *
+     * \param url       The URL to POST
+     * \param body      The body of the request
+     * \param headers   (Optional) Headers to pass to add to the request
+     *
+     * \throws SessionInitError          Unable to initialise the session
+     * \throws HTTPRequestFailedError    Server response wasn't OK (!= 200)
+     *
+     * \returns    The data returned from the server
+     */
+    virtual std::shared_ptr<JSON_Value> POST(
+        const std::string& url,
+        const std::shared_ptr<JSON_Value> body,
+        const std::map<std::string, std::string>& headers =
+            std::map<std::string, std::string>()) = 0;
+    /**
+     * \brief GETs data from a server
+     *
+     * \param url       The URL to GET
+     * \param headers   (Optional) Headers to pass to add to the request
+     *
+     * \throws SessionInitError          Unable to initialise the session
+     * \throws HTTPRequestFailedError    Server response wasn't OK (!= 200)
+     *
+     * \returns    The data returned from the server
+     */
+    virtual std::shared_ptr<JSON_Value> GET(
+        const std::string& url,
+        const std::map<std::string, std::string>& headers =
+            std::map<std::string, std::string>()) = 0;
+};
+
+
+#endif  // MERCURY__HTTP_HTTP_CLIENT_INTERFACE_H_

--- a/include/mercury/kw/kw.h
+++ b/include/mercury/kw/kw.h
@@ -8,10 +8,16 @@
  *
  */
 
-#ifndef MERCURY_KW_H
-#define MERCURY_KW_H
+#ifndef MERCURY_KW_KW_H_
+#define MERCURY_KW_KW_H_
 
+
+#include <memory>
 #include <string>
+
+#include "mercury/_http/http_client.h"
+#include "mercury/_http/http_client_interface.h"
+
 using std::string;
 
 /**
@@ -22,8 +28,12 @@ class KanoWorld
 {
  public:
     /**
-     * \brief Sets the system wallpaper.
+     * \brief Constructor
+     *
+     * \param client    (Optional) The HTTP client to use for requests
      */
+    explicit KanoWorld(std::shared_ptr<IHTTPClient> client =
+        std::make_shared<HTTPClient>());
     bool login(string username, string password, bool verbose);
     bool refresh_token(string token, bool verbose);
 
@@ -34,6 +44,16 @@ class KanoWorld
 
     bool am_i_logged_in(void);
     string whoami(void);
+
+    /**
+     * \brief Determine if the user's account has been verified with parental
+     *        permission.
+     */
+    bool is_account_verified();
+
+ private:
+    std::shared_ptr<IHTTPClient> http_client;
 };
 
-#endif  // MERCURY_KW_H
+
+#endif  // MERCURY_KW_KW_H_

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,14 +2,19 @@ project(mercury VERSION 0.1 LANGUAGES CXX)
 
 # Compilation of sources into object
 
+find_package(OpenSSL)
+
 add_library(mercury_obj OBJECT
     theme/theme.cpp
     kw/kw.cpp
+    _http/http_client.cpp
 )
 target_include_directories(mercury_obj PUBLIC
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/../include>
     $<BUILD_INTERFACE:${CONAN_INCLUDE_DIRS_LIBCURL}>
     $<BUILD_INTERFACE:${CONAN_INCLUDE_DIRS_PARSON}>
+    $<BUILD_INTERFACE:${CONAN_INCLUDE_DIRS_POCO}>
+    ${OPENSSL_INCLUDE_DIR}
     $<INSTALL_INTERFACE:include>
 )
 
@@ -29,20 +34,24 @@ target_include_directories(mercury_shared PUBLIC
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/../include>
     $<BUILD_INTERFACE:${CONAN_INCLUDE_DIRS_LIBCURL}>
     $<BUILD_INTERFACE:${CONAN_INCLUDE_DIRS_PARSON}>
+    $<BUILD_INTERFACE:${CONAN_INCLUDE_DIRS_POCO}>
+    ${OPENSSL_INCLUDE_DIR}
     $<INSTALL_INTERFACE:include>
 )
 target_include_directories(mercury_static PUBLIC
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/../include>
     $<BUILD_INTERFACE:${CONAN_INCLUDE_DIRS_LIBCURL}>
     $<BUILD_INTERFACE:${CONAN_INCLUDE_DIRS_PARSON}>
+    $<BUILD_INTERFACE:${CONAN_INCLUDE_DIRS_POCO}>
+    ${OPENSSL_INCLUDE_DIR}
     $<INSTALL_INTERFACE:include>
     )
 
 target_link_libraries(mercury_shared
-    PUBLIC CONAN_PKG::libcurl CONAN_PKG::parson
+    PUBLIC CONAN_PKG::libcurl CONAN_PKG::parson CONAN_PKG::Poco ${OPENSSL_LIBRARIES}
 )
 target_link_libraries(mercury_static
-    PUBLIC CONAN_PKG::libcurl CONAN_PKG::parson
+    PUBLIC CONAN_PKG::libcurl CONAN_PKG::parson CONAN_PKG::Poco ${OPENSSL_LIBRARIES}
 )
 
 # Add swig subdirectory

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,6 +56,15 @@ target_link_libraries(mercury_static
 
 
 if (CMAKE_BUILD_TYPE MATCHES Debug)
+    target_compile_options(mercury_obj
+        PRIVATE -fsanitize=address,undefined -fno-sanitize-recover=all
+    )
+    target_link_options(mercury_shared
+        PRIVATE -fsanitize=address,undefined -fno-sanitize-recover=all
+    )
+    target_link_options(mercury_static
+        PRIVATE -fsanitize=address,undefined -fno-sanitize-recover=all
+    )
 
     # Add flags for coverage
     # TODO: Only do this if we are building the debug version

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(mercury_obj OBJECT
     _http/http_client.cpp
 )
 target_include_directories(mercury_obj PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/../include>
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/../../include>
     $<BUILD_INTERFACE:${CONAN_INCLUDE_DIRS_LIBCURL}>
     $<BUILD_INTERFACE:${CONAN_INCLUDE_DIRS_PARSON}>
     $<BUILD_INTERFACE:${CONAN_INCLUDE_DIRS_POCO}>
@@ -31,7 +31,7 @@ set_target_properties(mercury_static
 )
 
 target_include_directories(mercury_shared PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/../include>
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/../../include>
     $<BUILD_INTERFACE:${CONAN_INCLUDE_DIRS_LIBCURL}>
     $<BUILD_INTERFACE:${CONAN_INCLUDE_DIRS_PARSON}>
     $<BUILD_INTERFACE:${CONAN_INCLUDE_DIRS_POCO}>
@@ -39,7 +39,7 @@ target_include_directories(mercury_shared PUBLIC
     $<INSTALL_INTERFACE:include>
 )
 target_include_directories(mercury_static PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/../include>
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/../../include>
     $<BUILD_INTERFACE:${CONAN_INCLUDE_DIRS_LIBCURL}>
     $<BUILD_INTERFACE:${CONAN_INCLUDE_DIRS_PARSON}>
     $<BUILD_INTERFACE:${CONAN_INCLUDE_DIRS_POCO}>
@@ -53,6 +53,16 @@ target_link_libraries(mercury_shared
 target_link_libraries(mercury_static
     PUBLIC CONAN_PKG::libcurl CONAN_PKG::parson CONAN_PKG::Poco ${OPENSSL_LIBRARIES}
 )
+
+
+if (CMAKE_BUILD_TYPE MATCHES Debug)
+
+    # Add flags for coverage
+    # TODO: Only do this if we are building the debug version
+    include(CodeCoverage)
+    APPEND_COVERAGE_COMPILER_FLAGS()
+endif (CMAKE_BUILD_TYPE MATCHES Debug)
+
 
 # Add swig subdirectory
 add_subdirectory(swig)

--- a/src/_http/http_client.cpp
+++ b/src/_http/http_client.cpp
@@ -1,0 +1,137 @@
+/**
+ * \file http_client.cpp
+ *
+ * \copyright Copyright (C) 2019 Kano Computing Ltd.
+ *            License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ */
+
+#include "mercury/_http/http_client.h"
+
+#include <parson.h>
+#include <Poco/Net/AcceptCertificateHandler.h>
+#include <Poco/Net/Context.h>
+#include <Poco/Net/HTTPClientSession.h>
+#include <Poco/Net/HTTPMessage.h>
+#include <Poco/Net/HTTPRequest.h>
+#include <Poco/Net/HTTPResponse.h>
+#include <Poco/Net/HTTPSessionFactory.h>
+#include <Poco/Net/HTTPSessionInstantiator.h>
+#include <Poco/Net/HTTPSSessionInstantiator.h>
+#include <Poco/Net/SSLManager.h>
+#include <Poco/SharedPtr.h>
+#include <Poco/URI.h>
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+
+
+using Poco::Net::HTTPSessionFactory;
+using Poco::Net::HTTPSessionInstantiator;
+using Poco::Net::HTTPSSessionInstantiator;
+using Poco::Net::HTTPClientSession;
+using Poco::Net::HTTPRequest;
+using Poco::Net::HTTPResponse;
+using Poco::Net::HTTPMessage;
+using Poco::Net::Context;
+using Poco::Net::AcceptCertificateHandler;
+using Poco::Net::SSLManager;
+
+
+HTTPClient::HTTPClient() {
+    HTTPSessionInstantiator::registerInstantiator();
+    HTTPSSessionInstantiator::registerInstantiator();
+
+    // Prepare for SSLManager
+    Poco::SharedPtr<AcceptCertificateHandler> cert =
+        new AcceptCertificateHandler(false);
+    const Poco::Net::Context::Ptr context = new Context(
+        Context::CLIENT_USE, "", "", "", Context::VERIFY_NONE, 9, false,
+        "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
+    SSLManager::instance().initializeClient(0, cert, context);
+}
+
+
+std::shared_ptr<JSON_Value> HTTPClient::send_request(
+    const std::string& method,
+    const std::string& url,
+    const std::map<std::string, std::string>& headers,
+    const std::string& body
+) {
+    const Poco::URI uri(url);
+    std::unique_ptr<HTTPClientSession> session;
+
+    try {
+        session = std::unique_ptr<HTTPClientSession>(
+            HTTPSessionFactory::defaultFactory().createClientSession(uri));
+    } catch (const Poco::DataException& e) {
+        throw SessionInitError(e.message());
+    } catch (const std::exception& e) {
+        throw SessionInitError(e.what());
+    }
+
+    HTTPRequest request(method, uri.getPath(), HTTPMessage::HTTP_1_1);
+    request.setContentType("application/json");
+    request.setContentLength(body.length());
+    request.add("Accept", "application/json");
+
+    for (auto header : headers) {
+        request.set(header.first, header.second);
+    }
+
+    std::ostream& os = session->sendRequest(request);
+
+    if (!body.empty()) {
+        os << body;
+    }
+
+    HTTPResponse response;
+    std::istream& rs = session->receiveResponse(response);
+
+    int status_code = response.getStatus();
+    if (status_code != HTTPResponse::HTTP_OK) {
+        throw HTTPRequestFailedError(status_code, response.getReason());
+    }
+
+    std::ostringstream data_stream;
+    data_stream << rs.rdbuf();
+
+    return std::shared_ptr<JSON_Value>(
+        json_parse_string(data_stream.str().c_str()), json_value_free);
+}
+
+
+std::shared_ptr<JSON_Value> HTTPClient::POST(
+    const std::string& url,
+    const std::shared_ptr<JSON_Value> body,
+    const std::map<std::string, std::string>& headers) {
+    std::shared_ptr<char> body_str(
+        json_serialize_to_string(body.get()),
+        json_free_serialized_string);
+
+    return this->POST(url, body_str.get());
+}
+
+
+std::shared_ptr<JSON_Value> HTTPClient::POST(
+    const std::string& url,
+    const std::string& body,
+    const std::map<std::string, std::string>& headers) {
+    return this->send_request(
+        HTTPRequest::HTTP_POST,
+        url,
+        headers,
+        body);
+}
+
+
+std::shared_ptr<JSON_Value> HTTPClient::GET(
+    const std::string& url,
+    const std::map<std::string, std::string>& headers) {
+    return this->send_request(
+        HTTPRequest::HTTP_GET,
+        url,
+        headers);
+}

--- a/src/kw/kw.cpp
+++ b/src/kw/kw.cpp
@@ -7,13 +7,23 @@
  *  Kano World class methods implemntation
  */
 
-#include <string>
-using std::string;
 
 #include "mercury/kw/kw.h"
 
-#include <parson.h>
 #include <curl/curl.h>
+#include <parson.h>
+
+#include <memory>
+#include <string>
+
+#include "mercury/_http/http_client_interface.h"
+
+using std::string;
+
+
+KanoWorld::KanoWorld(std::shared_ptr<IHTTPClient> client) :
+    http_client(client) {
+}
 
 
 /**
@@ -164,7 +174,7 @@ bool KanoWorld::am_i_logged_in(void)
 {
     return false;
 }
-    
+
 
 /**
  *   Not implemented yet
@@ -172,4 +182,12 @@ bool KanoWorld::am_i_logged_in(void)
 string KanoWorld::whoami(void)
 {
     return string("");
+}
+
+
+/**
+ * \warning Not implemented
+ */
+bool KanoWorld::is_account_verified() {
+    return true;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,9 @@ target_include_directories(mercury_gtests PUBLIC
 )
 
 target_link_options(mercury_gtests
-    PRIVATE -Wl,-rpath,${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+    PRIVATE -fsanitize=address,undefined
+            -fno-sanitize-recover=all
+            -Wl,-rpath,${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
 )
 
 enable_testing()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,16 +13,12 @@ target_link_libraries(mercury_gtests
     PRIVATE CONAN_PKG::gtest
 )
 
-target_compile_options(mercury_gtests
-    PRIVATE -fprofile-arcs -ftest-coverage
-)
-
 target_include_directories(mercury_gtests PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/..>
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/../..>
 )
 
 target_link_options(mercury_gtests
-    PRIVATE -coverage -Wl,-rpath,${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+    PRIVATE -Wl,-rpath,${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
 )
 
 enable_testing()
@@ -32,12 +28,11 @@ gtest_discover_tests(mercury_gtests)
 include(CodeCoverage)
 APPEND_COVERAGE_COMPILER_FLAGS()
 set(COVERAGE_LCOV_EXCLUDES
-    '*/test/*' '*/.conan/*' '*v1/*'
+    '*/build/*' '*/test/*' '*/.conan/*' '*v1/*'
 )
 SETUP_TARGET_FOR_COVERAGE_LCOV(
     NAME coverage
     EXECUTABLE ctest -j ${n_cores}
-    ENVIRONMENT
     DEPENDENCIES
     mercury_obj
     mercury_static

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,10 @@ target_compile_options(mercury_gtests
     PRIVATE -fprofile-arcs -ftest-coverage
 )
 
+target_include_directories(mercury_gtests PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/..>
+)
+
 target_link_options(mercury_gtests
     PRIVATE -coverage -Wl,-rpath,${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
 )
@@ -33,6 +37,7 @@ set(COVERAGE_LCOV_EXCLUDES
 SETUP_TARGET_FOR_COVERAGE_LCOV(
     NAME coverage
     EXECUTABLE ctest -j ${n_cores}
+    ENVIRONMENT
     DEPENDENCIES
     mercury_obj
     mercury_static

--- a/test/kw/kw_apis.h
+++ b/test/kw/kw_apis.h
@@ -8,13 +8,22 @@
  *
  */
 
-#ifndef TEST_KW
-#define TEST_KW
+#ifndef TEST_KW_KW_APIS_H_
+#define TEST_KW_KW_APIS_H_
 
+#include <gmock/gmock.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
-
+#include <mercury/_http/http_client.h>
 #include <mercury/kw/kw.h>
+#include <parson/parson.h>
+#include <test/mocks/mock_http_client.h>
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+
 
 using testing::Eq;
 
@@ -105,4 +114,5 @@ TEST(kw, whoami)
     EXPECT_EQ(kw.whoami(), "");
 }
 
-#endif  // TEST_KW
+
+#endif  // TEST_KW_KW_APIS_H_

--- a/test/mocks/mock_http_client.h
+++ b/test/mocks/mock_http_client.h
@@ -1,0 +1,157 @@
+/**
+ * \file mock_http_client.cpp
+ *
+ * \copyright Copyright (C) 2019 Kano Computing Ltd.
+ *            License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ */
+
+
+#ifndef TEST_MOCKS_MOCK_HTTP_CLIENT_H_
+#define TEST_MOCKS_MOCK_HTTP_CLIENT_H_
+
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <mercury/_http/http_client.h>
+
+#include <map>
+#include <memory>
+#include <string>
+
+
+/**
+ * \class MockHTTPClient
+ * \brief Mock implementation of IHTTPClient
+ *
+ * This class can be used with the Google Mock framework to allow testing for
+ * calls and mocking out return values. Details can be found at:
+ *
+ *     github.com/google/googletest/blob/master/googlemock/docs/ForDummies.md
+ *
+ * Note that because of the limitations of Google Mock with optional parameters
+ * we define the main function methods to just point to internal `*_impl()`
+ * equivalents of them. For this reason, all tests should check for these
+ * internal implementation functions.
+ *
+ * For example:
+ *
+ * ```
+ * MockHTTPClient client;
+ * EXPECT_CALL(
+ *     client,
+ *     GET_impl(
+ *         "http://www.example.com",
+ *         std::map<std::string, std::string>()))
+ *     .Times(3)
+ *     .WillRepeatedly(testing::Return(nullptr));
+ *
+ * test_func(client);
+ * ```
+ *
+ * This will check that the function GET_impl() gets called with
+ * "http://www.example.com" and an empty map of headers 3 times, each time
+ * returning `nullptr`. This could be because `GET()` is called directly with
+ * the two parameters or because it is called and uses the optional parameter.
+ * Ultimately, this makes no difference from the test's perspective.
+ *
+ */
+class MockHTTPClient : public IHTTPClient {
+ public:
+    /**
+     * \brief Google Mock doesn't permit optional arguments so simply implement
+     *        the mocked function signature and offload to the mocked
+     *        implementation (impl_POST)
+     *
+     * \param url       The URL to POST
+     * \param body      The body of the request
+     * \param headers   (Optional) Headers to pass to add to the request
+     */
+    virtual std::shared_ptr<JSON_Value> POST(
+        const std::string& url,
+        const std::string& body,
+        const std::map<std::string, std::string>& headers =
+            std::map<std::string, std::string>()) {
+        return this->POST_impl(url, body, headers);
+    }
+    /**
+     * \brief Google Mock doesn't permit optional arguments so simply implement
+     *        the mocked function signature and offload to the mocked
+     *        implementation (impl_POST)
+     *
+     * \param url       The URL to POST
+     * \param body      The body of the request
+     * \param headers   (Optional) Headers to pass to add to the request
+     */
+    virtual std::shared_ptr<JSON_Value> POST(
+        const std::string& url,
+        std::shared_ptr<JSON_Value> body,
+        const std::map<std::string, std::string>& headers =
+            std::map<std::string, std::string>()) {
+        return this->POST_impl(url, body, headers);
+    }
+    /**
+     * \brief Google Mock doesn't permit optional arguments so simply implement
+     *        the mocked function signature and offload to the mocked
+     *        implementation (impl_GET)
+     *
+     * \param url       The URL to GET
+     * \param headers   (Optional) Headers to pass to add to the request
+     */
+    virtual std::shared_ptr<JSON_Value> GET(
+        const std::string& url,
+        const std::map<std::string, std::string>& headers =
+            std::map<std::string, std::string>()) {
+        return this->GET_impl(url, headers);
+    }
+
+    /**
+     * \brief Internal mocked version of the POST to account for optional
+     *        parameters to Google Mock's mocked function. This is the function
+     *        that you should be checking to determine whether the function was
+     *        run.
+     *
+     * \param url       The URL to POST
+     * \param body      The body of the request
+     * \param headers   Headers to pass to add to the request
+     */
+    MOCK_METHOD3(
+        POST_impl,
+        std::shared_ptr<JSON_Value>(
+            const std::string& url,
+            const std::string& body,
+            const std::map<std::string, std::string>& headers));
+    /**
+     * \brief Internal mocked version of the POST to account for optional
+     *        parameters to Google Mock's mocked function. This is the function
+     *        that you should be checking to determine whether the function was
+     *        run.
+     *
+     * \param url       The URL to POST
+     * \param body      The body of the request
+     * \param headers   Headers to pass to add to the request
+     */
+    MOCK_METHOD3(
+        POST_impl,
+        std::shared_ptr<JSON_Value>(
+            const std::string& url,
+            std::shared_ptr<JSON_Value> body,
+            const std::map<std::string, std::string>& headers));
+    /**
+     * \brief Internal mocked version of the GET to account for optional
+     *        parameters to Google Mock's mocked function. This is the function
+     *        that you should be checking to determine whether the function was
+     *        run.
+     *
+     * \param url       The URL to GET
+     * \param headers   Headers to pass to add to the request
+     */
+    MOCK_METHOD2(
+        GET_impl,
+        std::shared_ptr<JSON_Value>(
+            const std::string& url,
+            const std::map<std::string, std::string>& headers));
+};
+
+
+#endif  // TEST_MOCKS_MOCK_HTTP_CLIENT_H_

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -12,8 +12,9 @@
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
-#include "theme/theme.h"
 #include "kw/kw_apis.h"
+#include "theme/theme.h"
+
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
Create a basic HTTP client implementation using the Poco framework and
implementing a client interface. Also create a mock to use for testing.

Separate the release from the debug build targets to allow optimisations
on the objects that get deployed.

Enable the address (ASan) and undefined behaviour (UBSan) sanitizers
while running the tests. This adds extra checking for errors during the

Build: Don't build tests when building for Release