### PR TITLE
Lint: Fix include root directory

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,7 +1,10 @@
 set noparent
 linelength=80
 
+root=include/
+
 exclude_files=build
+exclude_files=cmake
 
 filter=+build/class,
 filter=+build/c++11,

--- a/include/CPPLINT.cfg
+++ b/include/CPPLINT.cfg
@@ -1,1 +1,1 @@
-root=include
+root=.

--- a/include/mercury/kw/kw.h
+++ b/include/mercury/kw/kw.h
@@ -8,8 +8,8 @@
  *
  */
 
-#ifndef MERCURY_KW_H
-#define MERCURY_KW_H
+#ifndef MERCURY_KW_KW_H_
+#define MERCURY_KW_KW_H_
 
 #include <string>
 using std::string;
@@ -36,4 +36,4 @@ class KanoWorld
     string whoami(void);
 };
 
-#endif  // MERCURY_KW_H
+#endif  // MERCURY_KW_KW_H_


### PR DESCRIPTION
Allow `cpplint` to find the options for the header files by moving the
header-specific options to the global configuration file.