### PR TITLE
[OS-1009] World: Add setters for token, expiration and verified

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, CMake
+from conans import ConanFile, CMake, tools
 
 
 class MercuryConan(ConanFile):
@@ -28,7 +28,7 @@ class MercuryConan(ConanFile):
     )
     generators = "cmake"
     default_options = {
-        "OpenSSL:no_threads": True
+        "OpenSSL:no_threads": not tools.os_info.is_macos
     }
 
     def build(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,8 +9,11 @@ class MercuryConan(ConanFile):
     description = ""
     settings = "os", "compiler", "build_type", "arch"
     options = {
+        "shared": [True, False],
     }
     default_options = {
+        "shared": False,
+        "OpenSSL:no_threads": not tools.os_info.is_macos
     }
     generators = "cmake", "qmake"
     exports_sources = [
@@ -27,9 +30,6 @@ class MercuryConan(ConanFile):
         "Poco/1.9.2@pocoproject/stable",
     )
     generators = "cmake"
-    default_options = {
-        "OpenSSL:no_threads": not tools.os_info.is_macos
-    }
 
     def build(self):
         cmake = CMake(self)
@@ -47,9 +47,12 @@ class MercuryConan(ConanFile):
         self.copy("*.h", dst="include", src="include")
         self.copy("*mercury.lib", dst="lib", keep_path=False)
         self.copy("*.dll", dst="bin", keep_path=False)
-        self.copy("*.so", dst="lib", keep_path=False)
-        self.copy("*.dylib", dst="lib", keep_path=False)
-        self.copy("*.a", dst="lib", keep_path=False)
+
+        if self.options.shared:
+            self.copy("*.so", dst="lib", keep_path=False)
+            self.copy("*.dylib", dst="lib", keep_path=False)
+        else:
+            self.copy("*.a", dst="lib", keep_path=False)
 
     def package_info(self):
         self.cpp_info.libs = ["mercury"]

--- a/include/CPPLINT.cfg
+++ b/include/CPPLINT.cfg
@@ -1,1 +1,1 @@
-root=include
+root=.

--- a/include/mercury/kw/kw.h
+++ b/include/mercury/kw/kw.h
@@ -53,23 +53,52 @@ class KanoWorld {
     string whoami() const;
 
     /**
-     * \brief Determine if the user's account has been verified with parental
-     *        permission.
-     *
-     * \param cache    (Optional) Whether to use the cached value or query
-     *                 directly from the API
+     * \brief Read from the cache if the account has been verified with
+     *        parental permission
      */
-    bool is_account_verified(const bool cache = true);
+    bool get_account_verified() const;
     /**
-     * \brief Clear the cached value of the account verification
+     * \brief Set the the account verified status
+     *
+     * \param verified    The value to set it to
+     * \param save        Whether to save changes to disk
      */
-    void clear_account_verified_cache();
+    void set_account_verified(const bool verified, const bool save = true);
+    /**
+     * \brief Refresh the cached value for whether the user's account has been
+     *        verified with parental permission.
+     *
+     * \param sticky   (Optional) Whether to use the cached value in the case
+     *                 where the account has been seen to be verified or query
+     *                 directly from the API every time.
+     */
+    bool refresh_account_verified(const bool sticky = false);
 
     /**
      * \brief Extract the authentication token
      */
     string get_token() const;
+    /**
+     * \brief Set the authentication token
+     *
+     * \param token_val   Value to set the token to.
+     * \param save        Whether to save changes to disk
+     */
+    void set_token(const string& token_val, const bool save = true);
+
+    /**
+     * \brief Extract the authentication token
+     */
     string get_expiration_date() const;
+    /**
+     * \brief Set the authentication token
+     *
+     * \param expiration   Value to set the expiration to.
+     * \param save         Whether to save changes to disk
+     */
+    void set_expiration_date(const string& expiration,
+                             const bool save = true);
+
     bool load_data();
 
  public:


### PR DESCRIPTION
Allow the setting externally for the core Kano World artefacts
(authentication token, expiration date and account verification status).
Switch all functions to use these rather than accessing the private
members directly. Add options to optionally saving to disk at moment of
setting or delay saving until several operations have been made.