### PR TITLE
World: Add a config file for setting the API URL

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,8 +5,8 @@ class MercuryConan(ConanFile):
     name = "Mercury"
     version = "1.0"
     license = "GPLv2"
-    url = ""
-    description = ""
+    url = "https://github.com/KanoComputing/mercury"
+    description = "A cross-platform base layer for configuring the system"
     settings = "os", "compiler", "build_type", "arch"
     options = {
         "shared": [True, False],
@@ -15,7 +15,6 @@ class MercuryConan(ConanFile):
         "shared": False,
         "OpenSSL:no_threads": not tools.os_info.is_macos
     }
-    generators = "cmake", "qmake"
     exports_sources = [
         "CMakeLists.txt",
         "src/*.cpp",
@@ -28,6 +27,7 @@ class MercuryConan(ConanFile):
         "gtest/1.8.1@bincrafters/stable",
         "parson/0.1.0@bincrafters/stable",
         "Poco/1.9.2@pocoproject/stable",
+        "yaml-cpp/0.6.2@bincrafters/stable",
     )
     generators = "cmake"
 

--- a/conf/kw_dev.yaml
+++ b/conf/kw_dev.yaml
@@ -1,0 +1,1 @@
+API_URL: https://worldapi.kano.me

--- a/include/mercury/kw/APIConfig.h
+++ b/include/mercury/kw/APIConfig.h
@@ -1,0 +1,88 @@
+/**
+ * \file APIConfig.h
+ *
+ * \copyright Copyright (C) 2019 Kano Computing Ltd.
+ *            License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * \brief Configuration file for web services
+ *
+ */
+
+#ifndef INCLUDE_MERCURY_KW_APICONFIG_H_
+#define INCLUDE_MERCURY_KW_APICONFIG_H_
+
+
+#include <yaml-cpp/yaml.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+
+namespace Mercury {
+namespace KanoWorld {
+
+
+/**
+ * \class APIConfig
+ * \brief Provides configurations for the API configurations
+ */
+class APIConfig {
+ public:
+    /**
+     * \brief Constructor
+     *
+     * \param config_files    (Optional) Config files to override defaults
+     */
+    explicit APIConfig(std::vector<std::string> config_files = {});
+
+    /**
+     * \brief Get the API URL
+     *
+     * \returns the configured API URL or https://worldapi.kano.me if one isn't
+     *          found
+     */
+    std::string get_api_url() const;
+
+    /**
+     * \brief Determines whether a given key exists
+     *
+     * \warning This doesn't guarantee that the value is of the required type
+     *          or that it is not empty
+     *
+     * \param key    They value's key
+     *
+     * \returns whether the key exists
+     */
+    bool has(const std::string& key);
+
+    /**
+     * \brief Get a value from the configuration
+     *
+     * \param key    They value's key
+     *
+     * \returns the key's value
+     */
+    template<typename T>
+    T get_value(const std::string& key) const {
+        for (const auto& config : this->configs) {
+            if (config[key]) {
+                return config[key].as<T>();
+            }
+        }
+
+        return T();
+    }
+
+ private:
+    const std::string API_URL_KEY;
+    const std::string SYSTEM_PATH;
+    std::vector<YAML::Node> configs;
+};
+
+
+};  // namespace KanoWorld
+};  // namespace Mercury
+
+
+#endif  // INCLUDE_MERCURY_KW_APICONFIG_H_

--- a/include/mercury/kw/kw.h
+++ b/include/mercury/kw/kw.h
@@ -17,7 +17,9 @@
 
 #include "mercury/http/http_client.h"
 #include "mercury/http/http_client_interface.h"
+#include "mercury/kw/APIConfig.h"
 
+using Mercury::KanoWorld::APIConfig;
 using std::make_shared;
 using std::shared_ptr;
 using std::string;
@@ -39,7 +41,7 @@ class KanoWorld {
      * \param client    (Optional) The HTTP client to use for requests
      */
     KanoWorld(
-        const string& url = "https://worldapi.kano.me",
+        const string& url = "",
         shared_ptr<Mercury::HTTP::IHTTPClient> client =
             make_shared<Mercury::HTTP::HTTPClient>());
 
@@ -115,6 +117,10 @@ class KanoWorld {
     string parse_token(const shared_ptr<JSON_Value> res) const;
     string parse_expiration_date(const shared_ptr<JSON_Value> res) const;
     bool save_data();
+    /**
+     * \brief Helper for initialising the api_url member variable
+     */
+    std::string init_api_url(const std::string& url) const;
 
  private:
     shared_ptr<Mercury::HTTP::IHTTPClient> http_client;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(mercury_obj OBJECT
     kes_dashboard_live_tiles_client/TileCache.cpp
     kes_dashboard_live_tiles_client/TileFactory.cpp
     kes_dashboard_live_tiles_client/TileManager.cpp
+    kw/APIConfig.cpp
     kw/kw.cpp
     theme/theme.cpp
     utils/Filesystem.cpp
@@ -50,10 +51,16 @@ target_include_directories(mercury_static PUBLIC
 )
 
 target_link_libraries(mercury_shared
-    PUBLIC CONAN_PKG::parson CONAN_PKG::Poco ${OPENSSL_LIBRARIES}
+    PUBLIC CONAN_PKG::parson
+           CONAN_PKG::Poco
+           CONAN_PKG::yaml-cpp
+           ${OPENSSL_LIBRARIES}
 )
 target_link_libraries(mercury_static
-    PUBLIC CONAN_PKG::parson CONAN_PKG::Poco ${OPENSSL_LIBRARIES}
+    PUBLIC CONAN_PKG::parson
+           CONAN_PKG::Poco
+           CONAN_PKG::yaml-cpp
+           ${OPENSSL_LIBRARIES}
 )
 
 

--- a/src/kw/APIConfig.cpp
+++ b/src/kw/APIConfig.cpp
@@ -1,0 +1,72 @@
+/**
+ * \file APIConfig.cpp
+ *
+ * \copyright Copyright (C) 2019 Kano Computing Ltd.
+ *            License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * \brief Configuration file for web services
+ *
+ */
+
+
+#include "mercury/kw/APIConfig.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "mercury/config.h"
+
+
+using Mercury::KanoWorld::APIConfig;
+using std::move;
+using std::string;
+using std::vector;
+
+
+APIConfig::APIConfig(vector<string> config_files) :
+        API_URL_KEY("API_URL"),
+        // FIXME: Find a cross-platform mechanism for this
+        SYSTEM_PATH("/etc/mercury-api.yaml") {
+#if CMAKE_BUILD_TYPE == Debug
+    config_files.push_back(
+        string(CMAKE_PROJ_BASE_DIR) + "conf/kw_dev.yaml");
+#endif  // DEBUG
+
+    config_files.push_back(SYSTEM_PATH);
+
+    for (const auto& path : config_files) {
+        YAML::Node config;
+        try {
+            config = YAML::LoadFile(path);
+        } catch (...) {
+            continue;
+        }
+
+        if (config.Type() == YAML::NodeType::Map) {
+            this->configs.push_back(move(config));
+        }
+    }
+}
+
+
+bool APIConfig::has(const std::string& key) {
+    for (const auto& config : this->configs) {
+        if (config[key]) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+
+string APIConfig::get_api_url() const {
+    string url = this->get_value<string>(this->API_URL_KEY);
+
+    if (!url.empty()) {
+        return url;
+    }
+
+    return "https://worldapi.kano.me";
+}

--- a/src/kw/kw.cpp
+++ b/src/kw/kw.cpp
@@ -43,7 +43,7 @@ KanoWorld::KanoWorld(const string& url, shared_ptr<IHTTPClient> client) :
         http_client(client),
         data_filename(string(getenv("HOME")) + "/" + ".mercury_kw.json"),
         token(""),
-        api_url(url),
+        api_url(init_api_url(url)),
         expiration_date(""),
         is_verified_cache(false) {
     load_data();
@@ -510,4 +510,13 @@ bool KanoWorld::is_account_verified_api() const {
     }
 
     return static_cast<bool>(verified);
+}
+
+
+string KanoWorld::init_api_url(const std::string& url) const {
+    if (!url.empty()) {
+        return url;
+    }
+
+    return APIConfig().get_api_url();
 }

--- a/test/fixtures/apiconfig/APIConfigFixture.h
+++ b/test/fixtures/apiconfig/APIConfigFixture.h
@@ -1,0 +1,40 @@
+/**
+ * \file KesDltResponsesFixture.h
+ *
+ * \copyright Copyright (C) 2019 Kano Computing Ltd.
+ *            License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * \brief     TODO
+ */
+
+
+#ifndef TEST_FIXTURES_APICONFIG_APICONFIGFIXTURE_H_
+#define TEST_FIXTURES_APICONFIG_APICONFIGFIXTURE_H_
+
+#include <gtest/gtest.h>
+
+using ::testing::Test;
+
+class APIConfigFixture : public Test {
+ public:
+    static std::string CONFIG_DIR;
+    static std::string BASE_CONFIG;
+    static std::string OVERRIDE_CONFIG;
+    static std::string INVALID_CONFIG;
+    static std::string MISSING_CONFIG;
+};
+
+
+std::string APIConfigFixture::CONFIG_DIR =  // NOLINT
+    string(CMAKE_PROJ_BASE_DIR) + "/test/fixtures/apiconfig/data";
+std::string APIConfigFixture::BASE_CONFIG =  // NOLINT
+    APIConfigFixture::CONFIG_DIR + "/base.yaml";
+std::string APIConfigFixture::OVERRIDE_CONFIG =  // NOLINT
+    APIConfigFixture::CONFIG_DIR + "/override.yaml";
+std::string APIConfigFixture::INVALID_CONFIG =  // NOLINT
+    APIConfigFixture::CONFIG_DIR + "/invalid.yaml";
+std::string APIConfigFixture::MISSING_CONFIG =  // NOLINT
+    APIConfigFixture::CONFIG_DIR + "/file_doesnt_exist.yaml";
+
+
+#endif  // TEST_FIXTURES_APICONFIG_APICONFIGFIXTURE_H_

--- a/test/fixtures/apiconfig/data/base.yaml
+++ b/test/fixtures/apiconfig/data/base.yaml
@@ -1,0 +1,4 @@
+API_URL: test_url
+empty_key:
+no_override: base no_override value
+override: base override value

--- a/test/fixtures/apiconfig/data/invalid.yaml
+++ b/test/fixtures/apiconfig/data/invalid.yaml
@@ -1,0 +1,1 @@
+this isn't valid YAML

--- a/test/fixtures/apiconfig/data/override.yaml
+++ b/test/fixtures/apiconfig/data/override.yaml
@@ -1,0 +1,1 @@
+override: overriden override value

--- a/test/kw/apiconfig.h
+++ b/test/kw/apiconfig.h
@@ -1,0 +1,100 @@
+/**
+ * \file apiconfig.h
+ *
+ * \copyright Copyright (C) 2019 Kano Computing Ltd.
+ *            License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * \brief Tests for the Mercury::KW - APIConfig - functions
+ *
+ */
+
+#ifndef TEST_KW_APICONFIG_H_
+#define TEST_KW_APICONFIG_H_
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <mercury/config.h>
+#include <mercury/kw/APIConfig.h>
+#include <mercury/kw/kw.h>
+#include <test/fixtures/apiconfig/APIConfigFixture.h>
+
+#include <string>
+
+
+using Mercury::KanoWorld::APIConfig;
+using Mercury::KanoWorld::KanoWorld;
+using std::string;
+using testing::Eq;
+
+
+TEST_F(APIConfigFixture, NoOverrides)
+{
+    APIConfig config({BASE_CONFIG});
+
+    EXPECT_EQ(config.get_api_url(), "test_url");
+    EXPECT_EQ(config.get_value<string>("no_override"),
+              "base no_override value");
+    EXPECT_EQ(config.get_value<string>("override"),
+              "base override value");
+    EXPECT_EQ(config.get_value<string>("missing_key"),
+              "");
+}
+
+
+TEST_F(APIConfigFixture, OverrideValues)
+{
+    APIConfig config({OVERRIDE_CONFIG, BASE_CONFIG});
+
+    EXPECT_EQ(config.get_api_url(), "test_url");
+    EXPECT_EQ(config.get_value<string>("no_override"),
+              "base no_override value");
+    EXPECT_EQ(config.get_value<string>("override"),
+              "overriden override value");
+    EXPECT_EQ(config.get_value<string>("missing_key"),
+              "");
+}
+
+
+TEST_F(APIConfigFixture, MalformedConfig)
+{
+    APIConfig config({OVERRIDE_CONFIG,
+                      INVALID_CONFIG,
+                      MISSING_CONFIG,
+                      BASE_CONFIG});
+
+    EXPECT_EQ(config.get_api_url(), "test_url");
+    EXPECT_EQ(config.get_value<string>("no_override"),
+              "base no_override value");
+    EXPECT_EQ(config.get_value<string>("override"),
+              "overriden override value");
+    EXPECT_EQ(config.get_value<string>("missing_key"),
+              "");
+}
+
+
+/**
+ * The config should pull from the repo when building for debug
+ */
+TEST_F(APIConfigFixture, NoArgsConfig)
+{
+    APIConfig config;
+
+    EXPECT_EQ(config.get_api_url(), "https://worldapi.kano.me");
+}
+
+
+/**
+ * The config can be queried to see if a value is present
+ */
+TEST_F(APIConfigFixture, HasValues)
+{
+    APIConfig config({BASE_CONFIG});
+
+    EXPECT_EQ(config.has("API_URL"), true);
+    EXPECT_EQ(config.has("empty_key"), true);
+    EXPECT_EQ(config.has("uknown_key"), false);
+}
+
+
+#endif  // TEST_KW_APICONFIG_H_

--- a/test/kw/kw_apis.h
+++ b/test/kw/kw_apis.h
@@ -33,6 +33,29 @@ using Mercury::KanoWorld::KanoWorld;
 using testing::Eq;
 
 
+/**
+ * Ensure that the API url is correctly set when no argument is passed to the
+ * constructor
+ */
+TEST(kw, DefaultConstructor) {
+    KanoWorld kw;
+
+    EXPECT_EQ(kw.api_url, "https://worldapi.kano.me");
+}
+
+
+/**
+ * Ensure that the API url is correctly set when an argument is passed to the
+ * constructor
+ */
+TEST(kw, URLConstructor) {
+    std::string url = "sometesturl";
+    KanoWorld kw(url);
+
+    EXPECT_EQ(kw.api_url, url);
+}
+
+
 TEST(kw, RenewTokenMalformed)
 {
     KanoWorld kw(KanoWorldAPI::URL);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -18,6 +18,7 @@
 #include "kes_dashboard_live_tiles_client/TestTileCache.h"
 #include "kes_dashboard_live_tiles_client/TestTileManager.h"
 
+#include "kw/apiconfig.h"
 #include "kw/kw_apis.h"
 #include "kw/kw_persistence.h"
 #include "kw/kw_server_data.h"


### PR DESCRIPTION
Allow the API URL to be set via a configuration file to allow system
testing to be done.