### PR TITLE
CI: Build and test the library on push

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,18 +3,90 @@
 @Library('kanolib')
 import build_deb_pkg
 
-stage ('Test') {
-    def test_repos = [
-    ]
+stage ('Build') {
+    node ('ubuntu_18.04_with_docker') {
+        docker.image('kanocomputing/mercury-builder').inside('--cap-add SYS_PTRACE') {
+            checkout scm
 
-    make_test(test_repos) {
-        sh "conan remote add dev-server http://dev.kano.me:9300"
-
-        sh "make build-release"
-        sh "make build-debug"
+            parallel(
+                'Build - Debug': {
+                    sh 'make build-debug'
+                },
+                'Build - Release': {
+                    sh 'make build-release'
+                }
+            )
+        }
     }
 }
 
-stage ('Build') {
+stage ('Test') {
+    node ('ubuntu_18.04_with_docker') {
+        docker.image('kanocomputing/mercury-builder').inside('--cap-add SYS_PTRACE') {
+            checkout scm
+
+            parallel(
+                'C++ Tests': {
+                    try {
+                        sh 'make test-library'
+                    } catch (e) {
+                        throw e
+                    } finally {
+                        xunit (
+                            testTimeMargin: '3000',
+                            thresholdMode: 1,
+                            thresholds: [
+                                skipped(failureThreshold: '0'),
+                                failed(failureThreshold: '0')
+                            ],
+                            tools: [
+                                CTest(
+                                    pattern: 'build/Debug/Testing/**/*.xml',
+                                    deleteOutputFiles: true,
+                                    failIfNotNew: false,
+                                    skipNoTestFiles: true,
+                                    stopProcessingIfError: true
+                                )
+                            ]
+                        )
+                        publishHTML([
+                            allowMissing: true,
+                            alwaysLinkToLastBuild: true,
+                            keepAll: true,
+                            reportDir: 'build/Debug/coverage',
+                            reportFiles: 'index.html',
+                            reportName: 'Code Coverage',
+                            reportTitles: ''
+                        ])
+                    }
+                },
+                'Python 3 Tests': {
+                    // FIXME: Python dependencies not installed
+                    // sh 'make test-python'
+                },
+                'Python 2 Tests': {
+                    // FIXME: Python dependencies not installed
+                    // sh 'make test-python2'
+                }
+            )
+        }
+    }
+}
+
+stage ('Upload Package') {
+    /**
+     * TODO: Push the build to Conan when pushing to master. Need to resolve
+     *       permissions issues with the Conan server.
+     *
+     * node ('ubuntu_18.04_with_docker') {
+     *     docker.image('kanocomputing/mercury-builder').inside() {
+     *         sh 'conan upload --remote dev-team --all --confirm "Mercury"
+     *     }
+     * }
+    */
+
+}
+
+stage ('Package') {
     autobuild_repo_pkg 'mercury'
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,11 +36,11 @@ gtest_discover_tests(mercury_gtests)
 include(CodeCoverage)
 APPEND_COVERAGE_COMPILER_FLAGS()
 set(COVERAGE_LCOV_EXCLUDES
-    '*/build/*' '*/test/*' '*/.conan/*' '*v1/*'
+    '*/build/*' '*/test/*' '*/.conan/*' '*v1/*' '/usr/include/*'
 )
 SETUP_TARGET_FOR_COVERAGE_LCOV(
     NAME coverage
-    EXECUTABLE ctest -j ${n_cores}
+    EXECUTABLE ctest -j ${n_cores} --no-compress-output -T test
     ENVIRONMENT LSAN_OPTIONS=verbosity=1:log_threads=1
     DEPENDENCIES
     mercury_obj


### PR DESCRIPTION
Resolve issues with building and running tests in the Docker container
on the server. Upload the test results and coverage report once the
tests have been run.