### PR TITLE
Fix broken tests brought by the previous changeset

### DIFF
--- a/test/kes_dashboard_live_tiles_client/TestTileManager.h
+++ b/test/kes_dashboard_live_tiles_client/TestTileManager.h
@@ -33,7 +33,7 @@ namespace KESDLTC {
 namespace test {
 
 /**
- * Check that TileManager.getCache(false) calls and returns
+ * Check that TileManager.getTiles(false) calls and returns
  * OnlineLoader.getTiles() when TileManager.isCooldown() is false.
  */
 TEST(TestTileManager, GetTilesCacheFalseNoCooldownRetrievesWithOnlineLoader) {
@@ -60,7 +60,7 @@ TEST(TestTileManager, GetTilesCacheFalseNoCooldownRetrievesWithOnlineLoader) {
 }
 
 /**
- * Check that TileManager.getCache(false) does not call OnlineLoader.getTiles()
+ * Check that TileManager.getTiles(false) does not call OnlineLoader.getTiles()
  * when TileManager.isCooldown() is true.
  */
 TEST(TestTileManager, GetTilesCacheFalseWithCooldownDoesNotSpamOnlineLoader) {
@@ -94,8 +94,9 @@ TEST(TestTileManager, GetTilesCacheFalseWithCooldownDoesNotSpamOnlineLoader) {
 }
 
 /**
- * Check that TileManager.getCache(false) returns OnlineLoader.getTiles()
- * and calls TileCache.update(result) when TileManager.isCooldown() is false.
+ * Check that TileManager.getTiles(false) returns OnlineLoader.getTiles()
+ * and calls TileCache.update(result) when TileManager.isCooldown() is false
+ * and result is not empty.
  */
 TEST(
     TestTileManager,
@@ -127,12 +128,13 @@ TEST(
 }
 
 /**
- * Check that TileManager.getCache(false) does not call TileCache.update()
+ * Check that TileManager.getTiles(false) does not call TileCache.update()
  * when TileManager.isCooldown() is false and OnlineLoader.getTiles() result
- * is empty.
+ * is empty and TileCache.getTiles() is not empty.
  */
-TEST(TestTileManager,
-     GetTilesCacheFalseNoCooldownDoesNotUpdateCacheWhenThereAreNoResults) {
+TEST(
+    TestTileManager,
+    GetTilesCacheFalseNoCooldownDoesNotUpdateCacheWhenThereAreNoResults) {
     // NOLINT
     auto mockOnlineLoader = std::make_shared<MockOnlineLoader>();
     auto mockTileCache = std::make_shared<MockTileCache>();
@@ -145,6 +147,9 @@ TEST(TestTileManager,
     KESDLTC::TileManager tileManager(
         "", mockOnlineLoader, mockTileCache, mockDefaultTileLoader);
 
+    ON_CALL(*mockTileCache, getTiles)
+        .WillByDefault(::testing::Return(tiles));
+
     EXPECT_CALL(*mockOnlineLoader, getTiles)
         .Times(1);
 
@@ -155,7 +160,7 @@ TEST(TestTileManager,
 }
 
 /**
- * Check that TileManager.getCache(false) returns TileCache.getTiles() when
+ * Check that TileManager.getTiles(false) returns TileCache.getTiles() when
  * TileManager.isCooldown() is false and OnlineLoader.getTiles() result
  * is empty.
  */
@@ -189,7 +194,7 @@ TEST(
 }
 
 /**
- * Check that TileManager.getCache(false) returns TileCache.getTiles() when
+ * Check that TileManager.getTiles(false) returns TileCache.getTiles() when
  * TileManager.isCooldown() is true.
  */
 TEST(TestTileManager, GetTilesCacheFalseWithCooldonwRetrievesFromTileCache) {
@@ -228,7 +233,7 @@ TEST(TestTileManager, GetTilesCacheFalseWithCooldonwRetrievesFromTileCache) {
 }
 
 /**
- * Check that TileManager.getCache(true) returns TileCache.getTiles().
+ * Check that TileManager.getTiles(true) returns TileCache.getTiles().
  */
 TEST(TestTileManager, GetTilesCacheTrueRetrievesFromTileCache) {
     auto mockOnlineLoader = std::make_shared<MockOnlineLoader>();
@@ -254,8 +259,8 @@ TEST(TestTileManager, GetTilesCacheTrueRetrievesFromTileCache) {
 }
 
 /**
- * Check that TileManager.getCache(true) returns DefaultTileLoader.getTiles()
- * when TileCache.getTiles() result is empty.
+ * Check that TileManager.getTiles(true) returns DefaultTileLoader.getTiles()
+ * when TileCache.getTiles() result is empty and calls TileCache.update().
  */
 TEST(TestTileManager, GetTilesCacheTrueRetrievesDefaultTilesWhenCacheIsEmpty) {
     auto mockOnlineLoader = std::make_shared<MockOnlineLoader>();
@@ -276,6 +281,9 @@ TEST(TestTileManager, GetTilesCacheTrueRetrievesDefaultTilesWhenCacheIsEmpty) {
         .Times(1);
 
     EXPECT_CALL(*mockDefaultTileLoader, getTiles)
+        .Times(1);
+
+    EXPECT_CALL(*mockTileCache, update(tiles))
         .Times(1);
 
     result = tileManager.getTiles(true);

--- a/test/kes_moma_picks_client/TestDefaultPaintingLoader.h
+++ b/test/kes_moma_picks_client/TestDefaultPaintingLoader.h
@@ -43,7 +43,7 @@ TEST(TestDefaultPaintingLoader, GetPaintingsCallsPaintingFactoryCreate) {
         .WillByDefault(::testing::Return(mockPainting));
 
     EXPECT_CALL(*mockPaintingFactory, create_impl)
-        .Times(4);
+        .Times(6);
 
     defaultPaintingLoader.getPaintings();
 }

--- a/test/kes_moma_picks_client/TestPaintingManager.h
+++ b/test/kes_moma_picks_client/TestPaintingManager.h
@@ -33,7 +33,7 @@ namespace KESMPC {
 namespace test {
 
 /**
- * Check that PaintingManager.getCache(false) calls and returns
+ * Check that PaintingManager.getPaintings(false) calls and returns
  * OnlineLoader.getPaintings() when PaintingManager.isCooldown() is false.
  */
 TEST(
@@ -64,7 +64,7 @@ TEST(
 }
 
 /**
- * Check that PaintingManager.getCache(false) does not call
+ * Check that PaintingManager.getPaintings(false) does not call
  * OnlineLoader.getPaintings() when PaintingManager.isCooldown() is true.
  */
 TEST(
@@ -102,9 +102,9 @@ TEST(
 }
 
 /**
- * Check that PaintingManager.getCache(false) returns
+ * Check that PaintingManager.getPaintings(false) returns
  * OnlineLoader.getPaintings() and calls PaintingCache.update(result)
- * when PaintingManager.isCooldown() is false.
+ * when PaintingManager.isCooldown() is false and result is not empty.
  */
 TEST(
     TestPaintingManager,
@@ -137,13 +137,14 @@ TEST(
 }
 
 /**
- * Check that PaintingManager.getCache(false) does not call
+ * Check that PaintingManager.getPaintings(false) does not call
  * PaintingCache.update() when PaintingManager.isCooldown() is false and
  * OnlineLoader.getPaintings() result
  * is empty.
  */
-TEST(TestPaintingManager,
-     GetPaintingsCacheFalseNoCooldownDoesNotUpdateCacheWhenThereAreNoResults) {
+TEST(
+    TestPaintingManager,
+    GetPaintingsCacheFalseNoCooldownDoesNotUpdateCacheWhenThereAreNoResults) {
     // NOLINT
     auto mockOnlineLoader = std::make_shared<MockOnlineLoader>();
     auto mockPaintingCache = std::make_shared<MockPaintingCache>();
@@ -157,6 +158,9 @@ TEST(TestPaintingManager,
     KESMPC::PaintingManager paintingManager(
         "", mockOnlineLoader, mockPaintingCache, mockDefaultPaintingLoader);
 
+    ON_CALL(*mockPaintingCache, getPaintings)
+        .WillByDefault(::testing::Return(paintings));
+
     EXPECT_CALL(*mockOnlineLoader, getPaintings)
         .Times(1);
 
@@ -167,7 +171,7 @@ TEST(TestPaintingManager,
 }
 
 /**
- * Check that PaintingManager.getCache(false) returns
+ * Check that PaintingManager.getPaintings(false) returns
  * PaintingCache.getPaintings() when PaintingManager.isCooldown() is false and
  * OnlineLoader.getPaintings() result is empty.
  */
@@ -202,7 +206,7 @@ TEST(
 }
 
 /**
- * Check that PaintingManager.getCache(false) returns
+ * Check that PaintingManager.getPaintings(false) returns
  * PaintingCache.getPaintings() when PaintingManager.isCooldown() is true.
  */
 TEST(
@@ -245,7 +249,7 @@ TEST(
 }
 
 /**
- * Check that PaintingManager.getCache(true) returns
+ * Check that PaintingManager.getPaintings(true) returns
  * PaintingCache.getPaintings().
  */
 TEST(TestPaintingManager, GetPaintingsCacheTrueRetrievesFromPaintingCache) {
@@ -273,9 +277,9 @@ TEST(TestPaintingManager, GetPaintingsCacheTrueRetrievesFromPaintingCache) {
 }
 
 /**
- * Check that PaintingManager.getCache(true) returns
+ * Check that PaintingManager.getPaintings(true) returns
  * DefaultPaintingLoader.getPaintings() when PaintingCache.getPaintings()
- * result is empty.
+ * result is empty and calls PaintingCache.update().
  */
 TEST(
     TestPaintingManager,
@@ -300,6 +304,9 @@ TEST(
         .Times(1);
 
     EXPECT_CALL(*mockDefaultPaintingLoader, getPaintings)
+        .Times(1);
+
+    EXPECT_CALL(*mockPaintingCache, update(paintings))
         .Times(1);
 
     result = paintingManager.getPaintings(true);


### PR DESCRIPTION
Oops, looks like I broke some tests in https://github.com/KanoComputing/mercury/pull/32