### PR TITLE
[OS-980, OS-1022] Threads: Add thread tests and fixes for KanoWorld

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 BUILD_DIR := build
 RELEASE :=
+CMAKE_EXTRA_OPTIONS :=
 CONAN_PROFILE=conan-platforms/conan-profile-$(shell uname -s)-$(shell uname -m).info
 
 .PHONY: build lint clean test docs
@@ -11,7 +12,7 @@ _build:
 	-conan remote add dev-server http://dev.kano.me:9300 || conan remote update dev-server http://dev.kano.me:9300
 	-cd build/$(RELEASE) && conan install -r dev-server --build=missing --profile=../../${CONAN_PROFILE} ../..
 	cd build/$(RELEASE) && conan install --build=missing --profile=../../${CONAN_PROFILE} ../..
-	cd build/$(RELEASE) && cmake -DCMAKE_BUILD_TYPE=$(RELEASE) ../..
+	cd build/$(RELEASE) && cmake -DCMAKE_BUILD_TYPE=$(RELEASE) $(CMAKE_EXTRA_OPTIONS) ../..
 	cd build/$(RELEASE) && make VERBOSE=1
 
 build-debug: RELEASE=Debug
@@ -27,6 +28,10 @@ clean:
 
 test-library: build-debug
 	cd build/Debug && CTEST_OUTPUT_ON_FAILURE=1 make coverage
+
+test-threads: CMAKE_EXTRA_OPTIONS += -DTHREAD_SANITIZER_SUPPORTED=ON
+test-threads: build-debug
+	./build/Debug/bin/mercury_thread_tests
 
 test-python: build-release test-python2
 	-cp -v build/Release/lib/_mercury_python3.so test/python3/_mercury.so

--- a/include/mercury/kw/kw.h
+++ b/include/mercury/kw/kw.h
@@ -12,6 +12,7 @@
 #define INCLUDE_MERCURY_KW_KW_H_
 
 
+#include <atomic>
 #include <memory>
 #include <string>
 
@@ -126,7 +127,7 @@ class KanoWorld {
     shared_ptr<Mercury::HTTP::IHTTPClient> http_client;
     string token;
     string expiration_date;
-    bool is_verified_cache;
+    std::atomic<bool> is_verified_cache;
 };
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,7 @@ project(mercury VERSION 0.1 LANGUAGES CXX)
 
 find_package(OpenSSL)
 
-add_library(mercury_obj OBJECT
+set(mercury_src
     http/http_client.cpp
     kes_dashboard_live_tiles_client/DefaultTileLoader.cpp
     kes_dashboard_live_tiles_client/OnlineLoader.cpp
@@ -18,6 +18,10 @@ add_library(mercury_obj OBJECT
     utils/Filesystem.cpp
     utils/String.cpp
     utils/Time.cpp
+)
+
+add_library(mercury_obj OBJECT
+    ${mercury_src}
 )
 target_include_directories(mercury_obj PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
@@ -66,17 +70,76 @@ target_link_libraries(mercury_static
 
 if (CMAKE_BUILD_TYPE MATCHES Debug)
     target_compile_options(mercury_obj
-        PRIVATE -fsanitize=address,undefined -fno-sanitize-recover=all
+        PUBLIC -fsanitize=address,undefined
+               -fno-omit-frame-pointer
+               -fno-sanitize-recover=all
     )
     target_link_options(mercury_shared
-        PRIVATE -fsanitize=address,undefined -fno-sanitize-recover=all
+        PUBLIC -fsanitize=address,undefined
+               -fno-omit-frame-pointer
+               -fno-sanitize-recover=all
     )
     target_link_options(mercury_static
-        PRIVATE -fsanitize=address,undefined -fno-sanitize-recover=all
+        PUBLIC -fsanitize=address,undefined
+               -fno-omit-frame-pointer
+               -fno-sanitize-recover=all
     )
 
+    # FIXME: Actually calculate whether the sanitizer is supported rather than
+    #        relying on a static variable. This could be done with something
+    #        like:
+    #
+    #            include(CheckCXXCompilerFlag)
+    #            check_cxx_compiler_flag('-fsanitize=thread'
+    #                                    THREAD_SANITIZER_SUPPORTED)
+    #
+    #        but was unable to get this to work properly
+    #
+    option(THREAD_SANITIZER_SUPPORTED
+           "Whether the thread sanitizer is supported"
+           OFF)
+
+    if (THREAD_SANITIZER_SUPPORTED)
+        add_library(mercury_thread_obj OBJECT
+            ${mercury_src}
+        )
+        target_include_directories(mercury_thread_obj PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+            $<BUILD_INTERFACE:${CONAN_INCLUDE_DIRS}>
+            $<INSTALL_INTERFACE:include>
+        )
+        set_property(TARGET mercury_thread_obj PROPERTY POSITION_INDEPENDENT_CODE ON)
+        target_compile_options(mercury_thread_obj
+            PUBLIC -fsanitize=thread,undefined
+                -fno-omit-frame-pointer
+                -fno-sanitize-recover=all
+        )
+
+        add_library(mercury_thread_static STATIC
+            $<TARGET_OBJECTS:mercury_thread_obj>
+        )
+        set_target_properties(mercury_thread_static
+            PROPERTIES OUTPUT_NAME mercury_thread
+        )
+        target_link_options(mercury_thread_static
+            PUBLIC -fsanitize=thread,undefined
+                -fno-omit-frame-pointer
+                -fno-sanitize-recover=all
+        )
+        target_include_directories(mercury_thread_static PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+            $<BUILD_INTERFACE:${CONAN_INCLUDE_DIRS}>
+            $<INSTALL_INTERFACE:include>
+        )
+        target_link_libraries(mercury_thread_static
+            PUBLIC CONAN_PKG::parson
+                CONAN_PKG::Poco
+                CONAN_PKG::yaml-cpp
+                ${OPENSSL_LIBRARIES}
+        )
+    endif()
+
     # Add flags for coverage
-    # TODO: Only do this if we are building the debug version
     include(CodeCoverage)
     APPEND_COVERAGE_COMPILER_FLAGS()
 endif (CMAKE_BUILD_TYPE MATCHES Debug)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,13 +14,11 @@ target_link_libraries(mercury_gtests
 )
 
 target_include_directories(mercury_gtests PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/../..>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
 )
 
 target_link_options(mercury_gtests
-    PRIVATE -fsanitize=address,undefined
-            -fno-sanitize-recover=all
-            -Wl,-rpath,${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+    PRIVATE -Wl,-rpath,${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
 )
 
 if (UNIX AND NOT APPLE)
@@ -31,6 +29,28 @@ endif ()
 
 enable_testing()
 gtest_discover_tests(mercury_gtests)
+
+# Thread tests
+
+if (THREAD_SANITIZER_SUPPORTED)
+    add_executable(mercury_thread_tests
+        thread_tests.cpp
+    )
+
+    target_link_libraries(mercury_thread_tests
+        PUBLIC mercury_thread_static
+        PRIVATE CONAN_PKG::gtest
+    )
+
+    target_include_directories(mercury_thread_tests PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+        ${CMAKE_SOURCE_DIR}/include
+    )
+
+    target_link_options(mercury_thread_tests
+        PRIVATE -Wl,-rpath,${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+    )
+endif()
 
 # Coverage
 include(CodeCoverage)

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -25,6 +25,9 @@
 
 #include "theme/theme.h"
 
+// Run thread tests through the address sanitizer
+#include "thread/TestKanoWorldRefresh.h"
+
 
 int main(int argc, char *argv[]) {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/thread/TestKanoWorldRefresh.h
+++ b/test/thread/TestKanoWorldRefresh.h
@@ -1,0 +1,106 @@
+/**
+ * \file TestKanoWorldRefresh.h
+ *
+ * \copyright Copyright (C) 2019 Kano Computing Ltd.
+ *            License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * \brief Tests for the Mercury::KW - Kano World - functions
+ *
+ */
+
+#ifndef TEST_THREAD_TESTKANOWORLDREFRESH_H_
+#define TEST_THREAD_TESTKANOWORLDREFRESH_H_
+
+#include <gmock/gmock.h>
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <chrono>  // NOLINT
+#include <functional>
+#include <random>
+#include <string>
+#include <thread>  // NOLINT
+#include <utility>
+#include <vector>
+
+#include "mercury/kw/kw.h"
+
+
+using testing::Eq;
+
+
+void random_delay(int max_time) {
+    static std::default_random_engine generator;
+    std::uniform_int_distribution<int> distribution(0, max_time);
+
+    int delay = distribution(generator);
+    std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+}
+
+
+TEST(KWRefreshThread, RefreshVerified) {
+    Mercury::KanoWorld::KanoWorld kw;
+    std::thread refresh_thr(
+        &Mercury::KanoWorld::KanoWorld::refresh_account_verified,
+        &kw,
+        false);
+
+    kw.get_account_verified();
+    refresh_thr.join();
+}
+
+
+TEST(KWRefreshThread, MultiRefreshVerified) {
+    int thread_count = 50;
+    Mercury::KanoWorld::KanoWorld kw;
+    std::vector<std::thread> threads;
+
+    for (int i = 0; i < thread_count; i++) {
+        std::thread refresh_thr(
+            &Mercury::KanoWorld::KanoWorld::refresh_account_verified,
+            &kw,
+            false);
+        threads.push_back(std::move(refresh_thr));
+    }
+
+    for (int i = 0; i < thread_count; i++) {
+        std::thread read_thr(
+            &Mercury::KanoWorld::KanoWorld::get_account_verified,
+            &kw);
+        threads.push_back(std::move(read_thr));
+    }
+
+    for (std::thread &thr : threads) {
+        thr.join();
+    }
+}
+
+
+TEST(KWReadWriteThread, ReadAndWriteTokenFromThreads) {
+    int thread_count = 50;
+    std::string token = "testtoken";
+    Mercury::KanoWorld::KanoWorld kw;
+    std::vector<std::thread> threads;
+
+    for (int i = 0; i < thread_count; i++) {
+        std::thread write_thr([token, &kw]() {
+            random_delay(1000);
+            kw.set_token(token);
+        });
+        threads.push_back(std::move(write_thr));
+    }
+
+    for (int i = 0; i < thread_count; i++) {
+        std::thread read_thr([&kw]() {
+            random_delay(1000);
+            kw.get_token();
+        });
+        threads.push_back(std::move(read_thr));
+    }
+
+    for (std::thread &thr : threads) {
+        thr.join();
+    }
+}
+
+#endif  // TEST_THREAD_TESTKANOWORLDREFRESH_H_

--- a/test/thread_tests.cpp
+++ b/test/thread_tests.cpp
@@ -1,0 +1,20 @@
+/**
+ * \file thread_tests.cpp
+ *
+ * \copyright Copyright (C) 2019 Kano Computing Ltd.
+ *            License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * \brief Main runner for all Google tests
+ *
+ */
+
+
+#include <gtest/gtest.h>
+
+#include "thread/TestKanoWorldRefresh.h"
+
+
+int main(int argc, char *argv[]) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Add tests for multi-threaded access to the `KanoWorld` class and utilise
the thread sanitizer.