### PR TITLE
 World: Add ability to get and set the username

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 mercury (4.3.2-0) unstable; urgency=low
 
   * Updated default Tiles supplied by KESDLTC
+  * Add ability to get and set the Kano World username
 
  -- Team Kano <dev@kano.me>  Min, 19 Aug 2019 17:25:00 +0100
 

--- a/include/mercury/kw/kw.h
+++ b/include/mercury/kw/kw.h
@@ -66,6 +66,19 @@ class KanoWorld {
     bool is_logged_in(const bool verbose = false);
 
     /**
+     * \brief Extract the Kano World username
+     */
+    std::string get_username() const;
+
+    /**
+     * \brief Set the Kano World username
+     *
+     * \param user        Value to set the token to.
+     * \param save        Whether to save changes to disk
+     */
+    void set_username(const std::string& user, const bool save = true);
+
+    /**
      * \brief Extract the authentication token
      */
     std::string get_token() const;
@@ -130,8 +143,21 @@ class KanoWorld {
     // TODO: private
     bool load_data();
 
-    // TODO: remove; this happens through webpages we can update live
-    bool login(const std::string& username, const std::string& password,
+    /**
+     * \brief Calls the login endpoint the username and password credentials.
+     *
+     * TODO: remove; this happens through webpages we can update live
+     * \warning This will be removed in the future
+     *
+     * This is a login to the Kano World Services API
+     *
+     * \param user        The username to log in as
+     * \param password    The password to the user account
+     * \param verbose     Be more descriptive on the transaction details
+     *
+     * \returns True if login was successful, false otherwise
+     */
+    bool login(const std::string& user, const std::string& password,
                const bool verbose = false);
 
     // TODO: remove
@@ -172,6 +198,7 @@ class KanoWorld {
 
  private:
     std::shared_ptr<Mercury::HTTP::IHTTPClient> http_client;
+    std::string username;
     std::string token;
     std::string expiration_date;
     std::atomic<bool> is_verified_cache;

--- a/src/kw/APIConfig.cpp
+++ b/src/kw/APIConfig.cpp
@@ -68,5 +68,5 @@ string APIConfig::get_api_url() const {
         return url;
     }
 
-    return "https://worldapi.kano.me";
+    return "https://worldapi.kes.kano.me";
 }

--- a/test/fixtures/apiconfig/APIConfigFixture.h
+++ b/test/fixtures/apiconfig/APIConfigFixture.h
@@ -12,6 +12,7 @@
 #define TEST_FIXTURES_APICONFIG_APICONFIGFIXTURE_H_
 
 #include <gtest/gtest.h>
+#include <string>
 
 using ::testing::Test;
 
@@ -26,7 +27,7 @@ class APIConfigFixture : public Test {
 
 
 std::string APIConfigFixture::CONFIG_DIR =  // NOLINT
-    string(CMAKE_PROJ_BASE_DIR) + "/test/fixtures/apiconfig/data";
+    std::string(CMAKE_PROJ_BASE_DIR) + "/test/fixtures/apiconfig/data";
 std::string APIConfigFixture::BASE_CONFIG =  // NOLINT
     APIConfigFixture::CONFIG_DIR + "/base.yaml";
 std::string APIConfigFixture::OVERRIDE_CONFIG =  // NOLINT

--- a/test/kw/apiconfig.h
+++ b/test/kw/apiconfig.h
@@ -80,7 +80,7 @@ TEST_F(APIConfigFixture, NoArgsConfig)
 {
     APIConfig config;
 
-    EXPECT_EQ(config.get_api_url(), "https://worldapi.kano.me");
+    EXPECT_EQ(config.get_api_url(), "https://worldapi.kes.kano.me");
 }
 
 

--- a/test/kw/kw_apis.h
+++ b/test/kw/kw_apis.h
@@ -40,7 +40,7 @@ using testing::Eq;
 TEST(kw, DefaultConstructor) {
     KanoWorld kw;
 
-    EXPECT_EQ(kw.api_url, "https://worldapi.kano.me");
+    EXPECT_EQ(kw.api_url, "https://worldapi.kes.kano.me");
 }
 
 

--- a/test/kw/kw_getters.h
+++ b/test/kw/kw_getters.h
@@ -1,0 +1,59 @@
+/**
+ * \file kw_getters.h
+ *
+ * \copyright Copyright (C) 2019 Kano Computing Ltd.
+ *            License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * \brief Tests for the Mercury::KW getters
+ *
+ */
+
+#ifndef TEST_KW_KW_GETTERS_H_
+#define TEST_KW_KW_GETTERS_H_
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <mercury/kw/kw.h>
+
+#include <limits>
+#include <random>
+#include <string>
+
+
+using Mercury::KanoWorld::KanoWorld;
+using testing::Eq;
+
+
+
+int get_random_number(int max = std::numeric_limits<int>::max()) {
+    static std::random_device rd;
+    std::default_random_engine generator(rd());
+    std::uniform_int_distribution<int> distribution(0, max);
+
+    return distribution(generator);
+}
+
+
+TEST(kw, SetUsernameWithSave)
+{
+    const std::string username = std::string("some-test-username-")
+        + std::to_string(get_random_number());
+
+    KanoWorld kw1;
+
+    // Sanity check
+    EXPECT_NE(kw1.get_username(), username);
+
+    kw1.set_username(username, true);
+
+    EXPECT_EQ(kw1.get_username(), username);
+
+    // Refresh object
+
+    KanoWorld kw2;
+    EXPECT_EQ(kw2.get_username(), username);
+}
+
+
+#endif  // TEST_KW_KW_GETTERS_H_

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -27,6 +27,7 @@
 
 #include "kw/apiconfig.h"
 #include "kw/kw_apis.h"
+#include "kw/kw_getters.h"
 #include "kw/kw_persistence.h"
 #include "kw/kw_server_data.h"
 

--- a/test/thread/TestKanoWorldRefresh.h
+++ b/test/thread/TestKanoWorldRefresh.h
@@ -30,7 +30,8 @@ using testing::Eq;
 
 
 void random_delay(int max_time) {
-    static std::default_random_engine generator;
+    static std::random_device rd;
+    std::default_random_engine generator(rd());
     std::uniform_int_distribution<int> distribution(0, max_time);
 
     int delay = distribution(generator);


### PR DESCRIPTION
### Add functions to get and set the Kano World username

### World: Switch to new API URL
Change the default API URL to be the KES production one.

### Tests: Fix random delay generator

The random delay generator would always produce the same delay due to it
being initialised each time with the same seed. Resolve this by using a
random device.