### PR TITLE
Fix 'const' for std::thread::join which isn't marked 'const'

### DIFF
--- a/test/thread/TestKanoWorldSave.h
+++ b/test/thread/TestKanoWorldSave.h
@@ -62,7 +62,7 @@ TEST_F(KWSaveThread, ReadAndWriteDataFromThreads) {
         threads.push_back(std::move(read_thr));
     }
 
-    for (const auto& thr : threads) {
+    for (auto& thr : threads) {
         thr.join();
     }
 }


### PR DESCRIPTION
This should fix the Jenkins build.