### PR TITLE
Verification: Update API URL schema

### DIFF
--- a/src/kw/kw.cpp
+++ b/src/kw/kw.cpp
@@ -471,11 +471,13 @@ bool KanoWorld::is_account_verified_api() const {
     const JSON_Object* const data = json_value_get_object(response.get());
 
     if (!json_object_dothas_value_of_type(
-            data, "data.user.isVerified", JSONBoolean)) {
+            data, "data.user.attributes.consent", JSONBoolean)) {
         return false;
     }
 
-    int verified = json_object_dotget_boolean(data, "data.user.isVerified");
+    int verified = json_object_dotget_boolean(
+        data, "data.user.attributes.consent"
+    );
 
     if (verified == -1) {
         return false;

--- a/test/fixtures/data/api_response/users/me/invalid_parental_consent.json
+++ b/test/fixtures/data/api_response/users/me/invalid_parental_consent.json
@@ -1,15 +1,17 @@
 {
     "data": {
         "user": {
-            "id": "01375358073836680585",
-            "username": "testuser",
+            "id": "01753536256467870280",
+            "username": "FineMelon",
             "roles": [],
-            "created": "2018-04-13T14:58:21.757522",
-            "modified": "2018-04-13T14:58:21.757522",
-            "isVerified": "true",
+            "attributes": {
+                "consent": "true"
+            },
+            "created": "2019-09-02T10:03:31.335872",
+            "modified": "2019-09-02T10:03:31.335872",
             "bio": null
         },
-        "aBurl": "https://s3-us-west-1.amazonaws.com/avatar.world.kano.me"
+        "aBurl": "https://avatar.worldapi.kes.kano.me"
     },
     "type": "success"
 }

--- a/test/fixtures/data/api_response/users/me/no_parental_consent.json
+++ b/test/fixtures/data/api_response/users/me/no_parental_consent.json
@@ -1,15 +1,17 @@
 {
     "data": {
         "user": {
-            "id": "01375358073836680585",
-            "username": "testuser",
+            "id": "01753536256467870280",
+            "username": "FineMelon",
             "roles": [],
-            "created": "2018-04-13T14:58:21.757522",
-            "modified": "2018-04-13T14:58:21.757522",
-            "isVerified": false,
+            "attributes": {
+                "consent": false
+            },
+            "created": "2019-09-02T10:03:31.335872",
+            "modified": "2019-09-02T10:03:31.335872",
             "bio": null
         },
-        "aBurl": "https://s3-us-west-1.amazonaws.com/avatar.world.kano.me"
+        "aBurl": "https://avatar.worldapi.kes.kano.me"
     },
     "type": "success"
 }

--- a/test/fixtures/data/api_response/users/me/parental_consent.json
+++ b/test/fixtures/data/api_response/users/me/parental_consent.json
@@ -1,15 +1,17 @@
 {
     "data": {
         "user": {
-            "id": "01375358073836680585",
-            "username": "testuser",
+            "id": "01753536256467870280",
+            "username": "FineMelon",
             "roles": [],
-            "created": "2018-04-13T14:58:21.757522",
-            "modified": "2018-04-13T14:58:21.757522",
-            "isVerified": true,
+            "attributes": {
+                "consent": true
+            },
+            "created": "2019-09-02T10:03:31.335872",
+            "modified": "2019-09-02T10:03:31.335872",
             "bio": null
         },
-        "aBurl": "https://s3-us-west-1.amazonaws.com/avatar.world.kano.me"
+        "aBurl": "https://avatar.worldapi.kes.kano.me"
     },
     "type": "success"
 }


### PR DESCRIPTION
The `/users/me` endpoint has changed the way that it reports consent to
now take the form

```json
{
    "data": {
        "user": {
            "id": "01753536256467870280",
            "username": "FineMelon",
            "roles": [],
            "attributes": {
                "consent": true
            },
            "created": "2019-09-02T10:03:31.335872",
            "modified": "2019-09-02T10:03:31.335872",
            "bio": null
        },
        "aBurl": "https://avatar.worldapi.kes.kano.me"
    },
    "type": "success"
}
```

Update the tests and parsing accordingly to account for this.