### PR TITLE
Compile project with C++14 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 # Minimum CMake version required to build the software
 cmake_minimum_required(VERSION 3.7.2 FATAL_ERROR)
 
-set (CMAKE_VERBOSE_MAKEFILE on)
+set(CMAKE_VERBOSE_MAKEFILE on)
 
 project(Mercury VERSION 0.1)
 
@@ -16,7 +16,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(UseBackportedModules)
 
 # Global settings
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 # Conan
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/test/test_package/CMakeLists.txt
+++ b/test/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(PackageTest CXX)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)


### PR DESCRIPTION
The gcc compiler in Debian Stretch supports this as is.

New features in more detail:
https://github.com/AnthonyCalandra/modern-cpp-features
http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1319r0.html