### PR TITLE
Fix exception thrown when using Mercury from root

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,10 @@
 mercury (4.3.3-0) unstable; urgency=low
 
   * Compiling project with C++14 standard
+  * Fixed issue with KanoWorld, KESDLT, KESMP clients when ran
+    under sudo
 
- -- Team Kano <dev@kano.me>  Fri, 27 Sep 2019 11:25:00 +0100
+ -- Team Kano <dev@kano.me>  Fri, 3 Oct 2019 14:25:00 +0100
 
 mercury (4.3.2-0) unstable; urgency=low
 

--- a/include/kes_dashboard_live_tiles_client/TileManager.h
+++ b/include/kes_dashboard_live_tiles_client/TileManager.h
@@ -12,17 +12,18 @@
 #define INCLUDE_KES_DASHBOARD_LIVE_TILES_CLIENT_TILEMANAGER_H_
 
 
-#include <stdlib.h>
-
 #include <list>
 #include <memory>
 #include <string>
 
+#include "kes_dashboard_live_tiles_client/internal/DefaultTileLoader.h"
 #include "kes_dashboard_live_tiles_client/internal/IOnlineLoader.h"
 #include "kes_dashboard_live_tiles_client/internal/ITileCache.h"
 #include "kes_dashboard_live_tiles_client/internal/ITileLoader.h"
 #include "kes_dashboard_live_tiles_client/ITile.h"
 #include "kes_dashboard_live_tiles_client/ITileManager.h"
+#include "mercury/utils/Environment.h"
+#include "mercury/utils/IEnvironment.h"
 
 
 namespace KESDLTC {
@@ -33,7 +34,10 @@ class TileManager : public ITileManager {
         const std::string& cacheDir = "",
         const std::shared_ptr<KESDLTC::internal::IOnlineLoader> onlineLoader = nullptr,  // NOLINT
         const std::shared_ptr<KESDLTC::internal::ITileCache> tileCache = nullptr,  // NOLINT
-        const std::shared_ptr<KESDLTC::internal::ITileLoader> defaultTileLoader = nullptr);  // NOLINT
+        const std::shared_ptr<KESDLTC::internal::ITileLoader> defaultTileLoader =  // NOLINT
+            std::make_shared<KESDLTC::internal::DefaultTileLoader>(),
+        const std::shared_ptr<Mercury::Utils::IEnvironment> env =
+            std::make_shared<Mercury::Utils::Environment>());  // NOLINT
     ~TileManager();
 
  public:  // ITileManager Methods.

--- a/include/kes_moma_picks_client/PaintingManager.h
+++ b/include/kes_moma_picks_client/PaintingManager.h
@@ -12,17 +12,18 @@
 #define INCLUDE_KES_MOMA_PICKS_CLIENT_PAINTINGMANAGER_H_
 
 
-#include <stdlib.h>
-
 #include <list>
 #include <memory>
 #include <string>
 
+#include "kes_moma_picks_client/internal/DefaultPaintingLoader.h"
 #include "kes_moma_picks_client/internal/IOnlineLoader.h"
 #include "kes_moma_picks_client/internal/IPaintingCache.h"
 #include "kes_moma_picks_client/internal/IPaintingLoader.h"
 #include "kes_moma_picks_client/IPainting.h"
 #include "kes_moma_picks_client/IPaintingManager.h"
+#include "mercury/utils/Environment.h"
+#include "mercury/utils/IEnvironment.h"
 
 
 namespace KESMPC {
@@ -33,7 +34,10 @@ class PaintingManager : public IPaintingManager {
         const std::string& cacheDir = "",
         const std::shared_ptr<KESMPC::internal::IOnlineLoader> onlineLoader = nullptr,  // NOLINT
         const std::shared_ptr<KESMPC::internal::IPaintingCache> paintingCache = nullptr,  // NOLINT
-        const std::shared_ptr<KESMPC::internal::IPaintingLoader> defaultPaintingLoader = nullptr);  // NOLINT
+        const std::shared_ptr<KESMPC::internal::IPaintingLoader> defaultPaintingLoader =  // NOLINT
+            std::make_shared<KESMPC::internal::DefaultPaintingLoader>(),
+        const std::shared_ptr<Mercury::Utils::IEnvironment> env =
+            std::make_shared<Mercury::Utils::Environment>());
     ~PaintingManager();
 
  public:  // IPaintingManager Methods.

--- a/include/mercury/kw/kw.h
+++ b/include/mercury/kw/kw.h
@@ -9,6 +9,7 @@
  *
  */
 
+
 #ifndef INCLUDE_MERCURY_KW_KW_H_
 #define INCLUDE_MERCURY_KW_KW_H_
 
@@ -23,6 +24,8 @@
 
 #include "mercury/http/http_client.h"
 #include "mercury/http/http_client_interface.h"
+#include "mercury/utils/Environment.h"
+#include "mercury/utils/IEnvironment.h"
 
 
 namespace Mercury {
@@ -41,8 +44,10 @@ class KanoWorld {
      */
     KanoWorld(
         const std::string& url = "",
-        std::shared_ptr<Mercury::HTTP::IHTTPClient> client =
-            std::make_shared<Mercury::HTTP::HTTPClient>());
+        const std::shared_ptr<Mercury::HTTP::IHTTPClient> client =
+            std::make_shared<Mercury::HTTP::HTTPClient>(),
+        const std::shared_ptr<Mercury::Utils::IEnvironment> env =
+            std::make_shared<Mercury::Utils::Environment>());
 
     /**
      * \brief Logs out the current user
@@ -224,7 +229,9 @@ class KanoWorld {
     std::mutex save_mutex;
 };
 
+
 };  // namespace KanoWorld
 };  // namespace Mercury
+
 
 #endif  // INCLUDE_MERCURY_KW_KW_H_

--- a/include/mercury/utils/Environment.h
+++ b/include/mercury/utils/Environment.h
@@ -22,7 +22,8 @@ namespace Utils {
 
 /**
  * \class Environment
- * \brief Interface for an Environment utility class.
+ * \brief Utility class which wraps standard C functions for environment
+          manipulation.
  */
 class Environment : public IEnvironment {
  public:  // Constructors & destructors.
@@ -30,7 +31,7 @@ class Environment : public IEnvironment {
     ~Environment();
 
  public:  // Methods.
-    std::string getenv(const std::string& variable) const override;
+    std::string get(const std::string& variable) const override;
 };
 
 }  // namespace Utils

--- a/include/mercury/utils/IEnvironment.h
+++ b/include/mercury/utils/IEnvironment.h
@@ -27,7 +27,7 @@ class IEnvironment {
     virtual ~IEnvironment() {}
 
  public:  // Methods.
-    virtual std::string getenv(const std::string& variable) const = 0;
+    virtual std::string get(const std::string& variable) const = 0;
 };
 
 }  // namespace Utils

--- a/src/kes_dashboard_live_tiles_client/TileManager.cpp
+++ b/src/kes_dashboard_live_tiles_client/TileManager.cpp
@@ -14,7 +14,6 @@
 #include <memory>
 #include <string>
 
-#include "kes_dashboard_live_tiles_client/internal/DefaultTileLoader.h"
 #include "kes_dashboard_live_tiles_client/internal/IOnlineLoader.h"
 #include "kes_dashboard_live_tiles_client/internal/ITileCache.h"
 #include "kes_dashboard_live_tiles_client/internal/ITileLoader.h"
@@ -22,6 +21,7 @@
 #include "kes_dashboard_live_tiles_client/internal/TileCache.h"
 #include "kes_dashboard_live_tiles_client/ITile.h"
 #include "kes_dashboard_live_tiles_client/TileManager.h"
+#include "mercury/utils/IEnvironment.h"
 #include "mercury/utils/Time.h"
 
 using std::cerr;
@@ -32,7 +32,6 @@ using std::make_shared;
 using std::shared_ptr;
 using std::string;
 
-using KESDLTC::internal::DefaultTileLoader;
 using KESDLTC::internal::IOnlineLoader;
 using KESDLTC::internal::ITileCache;
 using KESDLTC::internal::ITileLoader;
@@ -40,26 +39,26 @@ using KESDLTC::internal::OnlineLoader;
 using KESDLTC::internal::TileCache;
 using KESDLTC::ITile;
 using KESDLTC::TileManager;
+using Mercury::Utils::IEnvironment;
 
 
 TileManager::TileManager(
     const string& cacheDir,
     const shared_ptr<IOnlineLoader> onlineLoader,
     const shared_ptr<ITileCache> tileCache,
-    const shared_ptr<ITileLoader> defaultTileLoader):
+    const shared_ptr<ITileLoader> defaultTileLoader,
+    const shared_ptr<IEnvironment> env):
     cacheDir(cacheDir),
     onlineLoader(onlineLoader),
     tileCache(tileCache),
     defaultTileLoader(defaultTileLoader) {
     // NOLINT
     if (this->cacheDir == "")
-        this->cacheDir = string(getenv("HOME")) + "/" + this->CACHE_DIRNAME;
+        this->cacheDir = env->get("HOME") + "/" + this->CACHE_DIRNAME;
     if (this->onlineLoader == nullptr)
         this->onlineLoader = make_shared<OnlineLoader>(this->cacheDir);
     if (this->tileCache == nullptr)
         this->tileCache = make_shared<TileCache>(this->cacheDir);
-    if (this->defaultTileLoader == nullptr)
-        this->defaultTileLoader = make_shared<DefaultTileLoader>();
 }
 
 

--- a/src/kes_moma_picks_client/PaintingManager.cpp
+++ b/src/kes_moma_picks_client/PaintingManager.cpp
@@ -14,7 +14,6 @@
 #include <memory>
 #include <string>
 
-#include "kes_moma_picks_client/internal/DefaultPaintingLoader.h"
 #include "kes_moma_picks_client/internal/IOnlineLoader.h"
 #include "kes_moma_picks_client/internal/IPaintingCache.h"
 #include "kes_moma_picks_client/internal/IPaintingLoader.h"
@@ -22,6 +21,7 @@
 #include "kes_moma_picks_client/internal/PaintingCache.h"
 #include "kes_moma_picks_client/IPainting.h"
 #include "kes_moma_picks_client/PaintingManager.h"
+#include "mercury/utils/IEnvironment.h"
 #include "mercury/utils/Time.h"
 
 using std::cerr;
@@ -32,7 +32,6 @@ using std::make_shared;
 using std::shared_ptr;
 using std::string;
 
-using KESMPC::internal::DefaultPaintingLoader;
 using KESMPC::internal::IOnlineLoader;
 using KESMPC::internal::IPaintingCache;
 using KESMPC::internal::IPaintingLoader;
@@ -40,26 +39,26 @@ using KESMPC::internal::OnlineLoader;
 using KESMPC::internal::PaintingCache;
 using KESMPC::IPainting;
 using KESMPC::PaintingManager;
+using Mercury::Utils::IEnvironment;
 
 
 PaintingManager::PaintingManager(
     const string& cacheDir,
     const shared_ptr<IOnlineLoader> onlineLoader,
     const shared_ptr<IPaintingCache> paintingCache,
-    const shared_ptr<IPaintingLoader> defaultPaintingLoader):
+    const shared_ptr<IPaintingLoader> defaultPaintingLoader,
+    const shared_ptr<IEnvironment> env):
     cacheDir(cacheDir),
     onlineLoader(onlineLoader),
     paintingCache(paintingCache),
     defaultPaintingLoader(defaultPaintingLoader) {
     // NOLINT
     if (this->cacheDir == "")
-        this->cacheDir = string(getenv("HOME")) + "/" + this->CACHE_DIRNAME;
+        this->cacheDir = env->get("HOME") + "/" + this->CACHE_DIRNAME;
     if (this->onlineLoader == nullptr)
         this->onlineLoader = make_shared<OnlineLoader>(this->cacheDir);
     if (this->paintingCache == nullptr)
         this->paintingCache = make_shared<PaintingCache>(this->cacheDir);
-    if (this->defaultPaintingLoader == nullptr)
-        this->defaultPaintingLoader = make_shared<DefaultPaintingLoader>();
 }
 
 

--- a/src/kw/kw.cpp
+++ b/src/kw/kw.cpp
@@ -9,7 +9,6 @@
 
 
 #include <parson.h>
-#include <stdlib.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -24,15 +23,8 @@
 #include "mercury/http/http_client_interface.h"
 #include "mercury/kw/APIConfig.h"
 #include "mercury/kw/kw.h"
-
+#include "mercury/utils/IEnvironment.h"
 #include "mercury/utils/Time.h"
-
-using Mercury::HTTP::IHTTPClient;
-using Mercury::HTTP::HTTPRequestFailedError;
-using Mercury::HTTP::SessionInitError;
-
-using Mercury::KanoWorld::APIConfig;
-using Mercury::KanoWorld::KanoWorld;
 
 using std::chrono::duration_cast;
 using std::chrono::milliseconds;
@@ -46,10 +38,22 @@ using std::make_pair;
 using std::shared_ptr;
 using std::string;
 
+using Mercury::HTTP::IHTTPClient;
+using Mercury::HTTP::HTTPRequestFailedError;
+using Mercury::HTTP::SessionInitError;
 
-KanoWorld::KanoWorld(const string& url, shared_ptr<IHTTPClient> client) :
+using Mercury::KanoWorld::APIConfig;
+using Mercury::KanoWorld::KanoWorld;
+
+using Mercury::Utils::IEnvironment;
+
+
+KanoWorld::KanoWorld(
+    const string& url,
+    const shared_ptr<IHTTPClient> client,
+    const shared_ptr<IEnvironment> env):
         http_client(client),
-        data_filename(string(getenv("HOME")) + "/.mercury_kw.json"),
+        data_filename(env->get("HOME") + "/.mercury_kw.json"),
         token(""),
         api_url(init_api_url(url)),
         expiration_date(0),

--- a/src/utils/Environment.cpp
+++ b/src/utils/Environment.cpp
@@ -29,7 +29,7 @@ Environment::~Environment() {
 }
 
 
-std::string Environment::getenv(const std::string& variable) const {
+std::string Environment::get(const std::string& variable) const {
     const char* value = std::getenv(variable.c_str());
     if (value == nullptr) {
         return string("");

--- a/test/kes_dashboard_live_tiles_client/TestTileManager.h
+++ b/test/kes_dashboard_live_tiles_client/TestTileManager.h
@@ -27,10 +27,27 @@
 #include "test/mocks/kes_dlt_cli/MockOnlineLoader.h"
 #include "test/mocks/kes_dlt_cli/MockTile.h"
 #include "test/mocks/kes_dlt_cli/MockTileCache.h"
+#include "test/mocks/MockEnvironment.h"
 
 
 namespace KESDLTC {
 namespace test {
+
+/**
+ * Check that TileManager constructor calls Environment.get("HOME").
+ */
+TEST(TestTileManager, ConstructorCallsEnvironmentGetEnvWithHome) {
+    auto mockEnvironment = std::make_shared<Mercury::Utils::test::MockEnvironment>();  // NOLINT
+
+    ON_CALL(*mockEnvironment, get)
+        .WillByDefault(::testing::Return(""));
+
+    EXPECT_CALL(*mockEnvironment, get("HOME"))
+        .Times(1);
+
+    KESDLTC::TileManager tileManager(
+        "", nullptr, nullptr, nullptr, mockEnvironment);
+}
 
 /**
  * Check that TileManager.getTiles(false) calls and returns

--- a/test/kes_moma_picks_client/TestPaintingManager.h
+++ b/test/kes_moma_picks_client/TestPaintingManager.h
@@ -27,10 +27,27 @@
 #include "test/mocks/kes_mp_cli/MockOnlineLoader.h"
 #include "test/mocks/kes_mp_cli/MockPainting.h"
 #include "test/mocks/kes_mp_cli/MockPaintingCache.h"
+#include "test/mocks/MockEnvironment.h"
 
 
 namespace KESMPC {
 namespace test {
+
+/**
+ * Check that PaintingManager constructor calls Environment.getenv("HOME").
+ */
+TEST(TestPaintingManager, ConstructorCallsEnvironmentGetEnvWithHome) {
+    auto mockEnvironment = std::make_shared<Mercury::Utils::test::MockEnvironment>();  // NOLINT
+
+    ON_CALL(*mockEnvironment, get)
+        .WillByDefault(::testing::Return(""));
+
+    EXPECT_CALL(*mockEnvironment, get("HOME"))
+        .Times(1);
+
+    KESMPC::PaintingManager paintingManager(
+        "", nullptr, nullptr, nullptr, mockEnvironment);
+}
 
 /**
  * Check that PaintingManager.getPaintings(false) calls and returns

--- a/test/mocks/MockEnvironment.h
+++ b/test/mocks/MockEnvironment.h
@@ -30,7 +30,7 @@ namespace test {
 class MockEnvironment : public Mercury::Utils::IEnvironment {
  public:  // IEnvironment Methods.
     MOCK_CONST_METHOD1(
-        getenv,
+        get,
         std::string(const std::string& variable));
 };
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -11,14 +11,14 @@
 
 #include <gtest/gtest.h>
 
-// #include "kes_dashboard_live_tiles_client/LiveTestTileManager.h"
+//  --- Run all unit tests ---
+
 #include "kes_dashboard_live_tiles_client/TestDefaultTileLoader.h"
 #include "kes_dashboard_live_tiles_client/TestOnlineLoader.h"
 #include "kes_dashboard_live_tiles_client/TestTile.h"
 #include "kes_dashboard_live_tiles_client/TestTileCache.h"
 #include "kes_dashboard_live_tiles_client/TestTileManager.h"
 
-// #include "kes_moma_picks_client/LiveTestPaintingManager.h"
 #include "kes_moma_picks_client/TestDefaultPaintingLoader.h"
 #include "kes_moma_picks_client/TestOnlineLoader.h"
 #include "kes_moma_picks_client/TestPainting.h"
@@ -33,7 +33,15 @@
 
 #include "theme/theme.h"
 
-// Run thread tests through the address sanitizer
+#include "unit/utils/TestEnvironment.h"
+
+// --- Run integration tests ---
+
+// #include "kes_dashboard_live_tiles_client/LiveTestTileManager.h"
+// #include "kes_moma_picks_client/LiveTestPaintingManager.h"
+
+// --- Run thread tests through the address sanitizer ---
+
 #include "thread/TestKanoWorldRefresh.h"
 #include "thread/TestKanoWorldSave.h"
 

--- a/test/unit/utils/TestEnvironment.h
+++ b/test/unit/utils/TestEnvironment.h
@@ -39,7 +39,7 @@ TEST(TestEnvironment, GetEnvReturnsEmptyStringForNonExistentVariables) {
     bool variableNotSet = std::getenv(variable.c_str()) == nullptr;
     ASSERT_TRUE(variableNotSet);
 
-    std::string returnedValue = env.getenv(variable);
+    std::string returnedValue = env.get(variable);
 
     EXPECT_STREQ(returnedValue.c_str(), "");
 }
@@ -64,7 +64,7 @@ INSTANTIATE_TEST_CASE_P(
 TEST_P(EnvironmentFixture, ParamGetEnvReturnsExpectedValue) {
     Mercury::Utils::Environment env;
 
-    std::string returnedValue = env.getenv(this->variable);
+    std::string returnedValue = env.get(this->variable);
 
     EXPECT_STREQ(returnedValue.c_str(), this->value.c_str());
 }


### PR DESCRIPTION
This was caused by calling the C function `getenv("HOME")` when the
variable did not exist and constructing a string from `nullptr`.