### PR TITLE
Fix problematic constructors

### DIFF
--- a/include/kes_dashboard_live_tiles_client/TileManager.h
+++ b/include/kes_dashboard_live_tiles_client/TileManager.h
@@ -16,13 +16,11 @@
 #include <memory>
 #include <string>
 
-#include "kes_dashboard_live_tiles_client/internal/DefaultTileLoader.h"
 #include "kes_dashboard_live_tiles_client/internal/IOnlineLoader.h"
 #include "kes_dashboard_live_tiles_client/internal/ITileCache.h"
 #include "kes_dashboard_live_tiles_client/internal/ITileLoader.h"
 #include "kes_dashboard_live_tiles_client/ITile.h"
 #include "kes_dashboard_live_tiles_client/ITileManager.h"
-#include "mercury/utils/Environment.h"
 #include "mercury/utils/IEnvironment.h"
 
 
@@ -34,10 +32,8 @@ class TileManager : public ITileManager {
         const std::string& cacheDir = "",
         const std::shared_ptr<KESDLTC::internal::IOnlineLoader> onlineLoader = nullptr,  // NOLINT
         const std::shared_ptr<KESDLTC::internal::ITileCache> tileCache = nullptr,  // NOLINT
-        const std::shared_ptr<KESDLTC::internal::ITileLoader> defaultTileLoader =  // NOLINT
-            std::make_shared<KESDLTC::internal::DefaultTileLoader>(),
-        const std::shared_ptr<Mercury::Utils::IEnvironment> env =
-            std::make_shared<Mercury::Utils::Environment>());  // NOLINT
+        const std::shared_ptr<KESDLTC::internal::ITileLoader> defaultTileLoader = nullptr,  // NOLINT
+        std::shared_ptr<Mercury::Utils::IEnvironment> env = nullptr);
     ~TileManager();
 
  public:  // ITileManager Methods.

--- a/include/kes_dashboard_live_tiles_client/internal/OnlineLoader.h
+++ b/include/kes_dashboard_live_tiles_client/internal/OnlineLoader.h
@@ -34,7 +34,7 @@ constexpr double ONE_HOUR_MS = 1000 * 60 * 60;  // in milliseconds
 
 class OnlineLoader : public IOnlineLoader {
  public:  // Constructors & destructors.
-    OnlineLoader(
+    explicit OnlineLoader(
         const std::string& cacheDir,
         const std::shared_ptr<Mercury::HTTP::IHTTPClient> httpClient =
             std::make_shared<Mercury::HTTP::HTTPClient>(),

--- a/include/kes_moma_picks_client/PaintingManager.h
+++ b/include/kes_moma_picks_client/PaintingManager.h
@@ -16,13 +16,11 @@
 #include <memory>
 #include <string>
 
-#include "kes_moma_picks_client/internal/DefaultPaintingLoader.h"
 #include "kes_moma_picks_client/internal/IOnlineLoader.h"
 #include "kes_moma_picks_client/internal/IPaintingCache.h"
 #include "kes_moma_picks_client/internal/IPaintingLoader.h"
 #include "kes_moma_picks_client/IPainting.h"
 #include "kes_moma_picks_client/IPaintingManager.h"
-#include "mercury/utils/Environment.h"
 #include "mercury/utils/IEnvironment.h"
 
 
@@ -34,10 +32,8 @@ class PaintingManager : public IPaintingManager {
         const std::string& cacheDir = "",
         const std::shared_ptr<KESMPC::internal::IOnlineLoader> onlineLoader = nullptr,  // NOLINT
         const std::shared_ptr<KESMPC::internal::IPaintingCache> paintingCache = nullptr,  // NOLINT
-        const std::shared_ptr<KESMPC::internal::IPaintingLoader> defaultPaintingLoader =  // NOLINT
-            std::make_shared<KESMPC::internal::DefaultPaintingLoader>(),
-        const std::shared_ptr<Mercury::Utils::IEnvironment> env =
-            std::make_shared<Mercury::Utils::Environment>());
+        const std::shared_ptr<KESMPC::internal::IPaintingLoader> defaultPaintingLoader = nullptr,  // NOLINT
+        const std::shared_ptr<Mercury::Utils::IEnvironment> env = nullptr);
     ~PaintingManager();
 
  public:  // IPaintingManager Methods.

--- a/include/kes_moma_picks_client/internal/OnlineLoader.h
+++ b/include/kes_moma_picks_client/internal/OnlineLoader.h
@@ -34,7 +34,7 @@ constexpr double ONE_HOUR_MS = 1000 * 60 * 60;  // in milliseconds
 
 class OnlineLoader : public IOnlineLoader {
  public:  // Constructors & destructors.
-    OnlineLoader(
+    explicit OnlineLoader(
         const std::string& cacheDir,
         const std::shared_ptr<Mercury::HTTP::IHTTPClient> httpClient =
             std::make_shared<Mercury::HTTP::HTTPClient>(),

--- a/src/kes_dashboard_live_tiles_client/TileManager.cpp
+++ b/src/kes_dashboard_live_tiles_client/TileManager.cpp
@@ -14,6 +14,7 @@
 #include <memory>
 #include <string>
 
+#include "kes_dashboard_live_tiles_client/internal/DefaultTileLoader.h"
 #include "kes_dashboard_live_tiles_client/internal/IOnlineLoader.h"
 #include "kes_dashboard_live_tiles_client/internal/ITileCache.h"
 #include "kes_dashboard_live_tiles_client/internal/ITileLoader.h"
@@ -21,6 +22,7 @@
 #include "kes_dashboard_live_tiles_client/internal/TileCache.h"
 #include "kes_dashboard_live_tiles_client/ITile.h"
 #include "kes_dashboard_live_tiles_client/TileManager.h"
+#include "mercury/utils/Environment.h"
 #include "mercury/utils/IEnvironment.h"
 #include "mercury/utils/Time.h"
 
@@ -32,6 +34,7 @@ using std::make_shared;
 using std::shared_ptr;
 using std::string;
 
+using KESDLTC::internal::DefaultTileLoader;
 using KESDLTC::internal::IOnlineLoader;
 using KESDLTC::internal::ITileCache;
 using KESDLTC::internal::ITileLoader;
@@ -40,6 +43,8 @@ using KESDLTC::internal::TileCache;
 using KESDLTC::ITile;
 using KESDLTC::TileManager;
 using Mercury::Utils::IEnvironment;
+using Mercury::Utils::Environment;
+
 
 
 TileManager::TileManager(
@@ -47,18 +52,22 @@ TileManager::TileManager(
     const shared_ptr<IOnlineLoader> onlineLoader,
     const shared_ptr<ITileCache> tileCache,
     const shared_ptr<ITileLoader> defaultTileLoader,
-    const shared_ptr<IEnvironment> env):
+    shared_ptr<IEnvironment> env):
     cacheDir(cacheDir),
     onlineLoader(onlineLoader),
     tileCache(tileCache),
     defaultTileLoader(defaultTileLoader) {
     // NOLINT
+    if (env == nullptr)
+        env = make_shared<Environment>();
     if (this->cacheDir == "")
         this->cacheDir = env->get("HOME") + "/" + this->CACHE_DIRNAME;
     if (this->onlineLoader == nullptr)
         this->onlineLoader = make_shared<OnlineLoader>(this->cacheDir);
     if (this->tileCache == nullptr)
         this->tileCache = make_shared<TileCache>(this->cacheDir);
+    if (this->defaultTileLoader == nullptr)
+        this->defaultTileLoader = make_shared<DefaultTileLoader>();
 }
 
 

--- a/src/kes_moma_picks_client/PaintingManager.cpp
+++ b/src/kes_moma_picks_client/PaintingManager.cpp
@@ -14,6 +14,7 @@
 #include <memory>
 #include <string>
 
+#include "kes_moma_picks_client/internal/DefaultPaintingLoader.h"
 #include "kes_moma_picks_client/internal/IOnlineLoader.h"
 #include "kes_moma_picks_client/internal/IPaintingCache.h"
 #include "kes_moma_picks_client/internal/IPaintingLoader.h"
@@ -21,6 +22,7 @@
 #include "kes_moma_picks_client/internal/PaintingCache.h"
 #include "kes_moma_picks_client/IPainting.h"
 #include "kes_moma_picks_client/PaintingManager.h"
+#include "mercury/utils/Environment.h"
 #include "mercury/utils/IEnvironment.h"
 #include "mercury/utils/Time.h"
 
@@ -32,6 +34,7 @@ using std::make_shared;
 using std::shared_ptr;
 using std::string;
 
+using KESMPC::internal::DefaultPaintingLoader;
 using KESMPC::internal::IOnlineLoader;
 using KESMPC::internal::IPaintingCache;
 using KESMPC::internal::IPaintingLoader;
@@ -40,6 +43,7 @@ using KESMPC::internal::PaintingCache;
 using KESMPC::IPainting;
 using KESMPC::PaintingManager;
 using Mercury::Utils::IEnvironment;
+using Mercury::Utils::Environment;
 
 
 PaintingManager::PaintingManager(
@@ -47,18 +51,22 @@ PaintingManager::PaintingManager(
     const shared_ptr<IOnlineLoader> onlineLoader,
     const shared_ptr<IPaintingCache> paintingCache,
     const shared_ptr<IPaintingLoader> defaultPaintingLoader,
-    const shared_ptr<IEnvironment> env):
+    shared_ptr<IEnvironment> env):
     cacheDir(cacheDir),
     onlineLoader(onlineLoader),
     paintingCache(paintingCache),
     defaultPaintingLoader(defaultPaintingLoader) {
     // NOLINT
+    if (env == nullptr)
+        env = make_shared<Environment>();
     if (this->cacheDir == "")
         this->cacheDir = env->get("HOME") + "/" + this->CACHE_DIRNAME;
     if (this->onlineLoader == nullptr)
         this->onlineLoader = make_shared<OnlineLoader>(this->cacheDir);
     if (this->paintingCache == nullptr)
         this->paintingCache = make_shared<PaintingCache>(this->cacheDir);
+    if (this->defaultPaintingLoader == nullptr)
+        this->defaultPaintingLoader = make_shared<DefaultPaintingLoader>();
 }
 
 

--- a/test/kes_dashboard_live_tiles_client/TestTileManager.h
+++ b/test/kes_dashboard_live_tiles_client/TestTileManager.h
@@ -33,6 +33,22 @@
 namespace KESDLTC {
 namespace test {
 
+
+/**
+ * Check that users of the class can use it through a pointer of its interface.
+ */
+TEST(TestTileManager, CanUseClassThroughInterfacePointer) {
+    std::shared_ptr<KESDLTC::ITileManager> sharedTileManager =
+        std::make_shared<KESDLTC::TileManager>();
+
+    std::unique_ptr<KESDLTC::ITileManager> uniqueTileManager =
+        std::make_unique<KESDLTC::TileManager>();
+
+    EXPECT_TRUE(sharedTileManager != nullptr);
+    EXPECT_TRUE(uniqueTileManager != nullptr);
+}
+
+
 /**
  * Check that TileManager constructor calls Environment.get("HOME").
  */

--- a/test/kes_moma_picks_client/TestPaintingManager.h
+++ b/test/kes_moma_picks_client/TestPaintingManager.h
@@ -19,6 +19,7 @@
 #include <memory>
 
 #include "kes_moma_picks_client/IPainting.h"
+#include "kes_moma_picks_client/IPaintingManager.h"
 #include "kes_moma_picks_client/PaintingManager.h"
 
 #include "mercury/utils/Time.h"
@@ -32,6 +33,21 @@
 
 namespace KESMPC {
 namespace test {
+
+
+/**
+ * Check that users of the class can use it through a pointer of its interface.
+ */
+TEST(TestPaintingManager, CanUseClassThroughInterfacePointer) {
+    std::shared_ptr<KESMPC::IPaintingManager> sharedPaintingManager =
+        std::make_shared<KESMPC::PaintingManager>();
+
+    std::unique_ptr<KESMPC::IPaintingManager> uniquePaintingManager =
+        std::make_unique<KESMPC::PaintingManager>();
+
+    EXPECT_TRUE(sharedPaintingManager != nullptr);
+    EXPECT_TRUE(uniquePaintingManager != nullptr);
+}
 
 /**
  * Check that PaintingManager constructor calls Environment.getenv("HOME").

--- a/test/unit/utils/TestEnvironment.h
+++ b/test/unit/utils/TestEnvironment.h
@@ -16,15 +16,32 @@
 #include <stdlib.h>
 
 #include <cstdlib>
+#include <memory>
 #include <string>
 
 #include "mercury/utils/Environment.h"
+#include "mercury/utils/IEnvironment.h"
 #include "test/fixtures/EnvironmentFixture.h"
 
 
 namespace Mercury {
 namespace Utils {
 namespace test {
+
+
+/**
+ * Check that users of the class can use it through a pointer of its interface.
+ */
+TEST(TestEnvironment, CanUseClassThroughInterfacePointer) {
+    std::shared_ptr<Mercury::Utils::IEnvironment> sharedEnvironment =
+        std::make_shared<Mercury::Utils::Environment>();
+
+    std::unique_ptr<Mercury::Utils::IEnvironment> uniqueEnvironment =
+        std::make_unique<Mercury::Utils::Environment>();
+
+    EXPECT_TRUE(sharedEnvironment != nullptr);
+    EXPECT_TRUE(uniqueEnvironment != nullptr);
+}
 
 
 /**


### PR DESCRIPTION
It would seem that in some particular circumstance users of TileManager
and (possibly) PaintingManager would have an issue constructing an
object through their interface using shared_ptr. The suspicion is that
it had something to do with the order of optional parameters and some
having nullptr values.