### PR TITLE
[OS-1068] Provide a timeout to the Http class

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ mercury (4.3.3-0) unstable; urgency=low
   * Compiling project with C++14 standard
   * Fixed issue with KanoWorld, KESDLT, KESMP clients when ran
     under sudo
+  * Added a timeout capability to HTTP class
 
  -- Team Kano <dev@kano.me>  Fri, 3 Oct 2019 14:25:00 +0100
 

--- a/include/mercury/http/http_client.h
+++ b/include/mercury/http/http_client.h
@@ -21,9 +21,10 @@
 
 #include "mercury/http/http_client_interface.h"
 
-
 namespace Mercury {
 namespace HTTP {
+
+#define DEFAULT_HTTP_CLIENT_TIMEOUT    15 // seconds
 
 /**
  * \class HTTPClient
@@ -32,6 +33,7 @@ namespace HTTP {
 class HTTPClient : public IHTTPClient {
  public:
     HTTPClient();
+    HTTPClient(int timeout_secs);
     std::shared_ptr<JSON_Value> POST(
         const std::string& url,
         const std::string& body,
@@ -49,6 +51,9 @@ class HTTPClient : public IHTTPClient {
     bool DL(
         const std::string& url,
         const std::string& path) override;
+
+    void set_http_client_timeout(int seconds);
+    int get_http_client_timeout();
 
  protected:
     /**
@@ -69,6 +74,8 @@ class HTTPClient : public IHTTPClient {
         const std::map<std::string, std::string>& headers =
             std::map<std::string, std::string>(),
         const std::string& body = "");
+
+    int http_client_timeout;
 };
 
 }  // namespace HTTP

--- a/test/kw/kw_apis.h
+++ b/test/kw/kw_apis.h
@@ -193,6 +193,9 @@ TEST_P(ParentalConsentAPI, TestAccountVerification)
 }
 
 
+/* TODO: Implement tests for HTTP class with a timeout */
+
+
 /**
  * KanoWorld::refresh_account_verified() should return false when the
  * HTTPClient throws an exception (for example, when there is a server error)


### PR DESCRIPTION
Provide a means to set a timeout for the HTTP class.
It builds fine but haven't actually tested.
Also, needs a test to make sure the timeout is set and works correctly.

