### PR TITLE
Fix potential memory corruption due to lifetime of default arguments

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,8 +3,9 @@ mercury (4.3.3-0) unstable; urgency=low
   * Compiling project with C++14 standard
   * Fixed issue with KanoWorld, KESDLT, KESMP clients when ran
     under sudo
+  * Fixed potential memory corruption issues
 
- -- Team Kano <dev@kano.me>  Fri, 3 Oct 2019 14:25:00 +0100
+ -- Team Kano <dev@kano.me>  Thu, 24 Oct 2019 22:25:00 +0100
 
 mercury (4.3.2-0) unstable; urgency=low
 

--- a/include/kes_dashboard_live_tiles_client/ITileFactory.h
+++ b/include/kes_dashboard_live_tiles_client/ITileFactory.h
@@ -16,6 +16,7 @@
 #include <string>
 
 #include "kes_dashboard_live_tiles_client/ITile.h"
+#include "mercury/http/http_client_interface.h"
 
 
 namespace KESDLTC {
@@ -35,7 +36,9 @@ class ITileFactory {
         const std::string& app,
         const std::string& openUrl,
         const std::string& fallbackUrl,
-        const std::string& coverPath = "") const = 0;
+        const std::string& coverPath = "",
+        const std::shared_ptr<Mercury::HTTP::IHTTPClient>& httpClient =
+            nullptr) const = 0;
 };
 
 }  // namespace KESDLTC

--- a/include/kes_dashboard_live_tiles_client/Tile.h
+++ b/include/kes_dashboard_live_tiles_client/Tile.h
@@ -18,8 +18,6 @@
 #include <string>
 
 #include "kes_dashboard_live_tiles_client/ITile.h"
-
-#include "mercury/http/http_client.h"
 #include "mercury/http/http_client_interface.h"
 
 
@@ -28,8 +26,7 @@ namespace KESDLTC {
 class Tile : public ITile {
  public:  // Constructors & destructors.
     explicit Tile(
-        const std::shared_ptr<Mercury::HTTP::IHTTPClient> httpClient =
-            std::make_shared<Mercury::HTTP::HTTPClient>());
+        const std::shared_ptr<Mercury::HTTP::IHTTPClient>& httpClient = nullptr);  // NOLINT
 
     Tile(const std::string& id,
          const std::string& cover,
@@ -40,10 +37,7 @@ class Tile : public ITile {
          const std::string& openUrl,
          const std::string& fallbackUrl,
          const std::string& coverPath = "",
-         const std::shared_ptr<Mercury::HTTP::IHTTPClient> httpClient =
-            std::make_shared<Mercury::HTTP::HTTPClient>());
-
-    ~Tile();
+         const std::shared_ptr<Mercury::HTTP::IHTTPClient>& httpClient = nullptr);  // NOLINT
 
  public:  // ISerialisable Methods.
     bool initialise(JSON_Value* serialisedData) override;
@@ -73,7 +67,7 @@ class Tile : public ITile {
     std::string app;
     std::string openUrl;
     std::string fallbackUrl;
-    const std::shared_ptr<Mercury::HTTP::IHTTPClient> httpClient;
+    std::shared_ptr<Mercury::HTTP::IHTTPClient> httpClient;
 };
 
 }  // namespace KESDLTC

--- a/include/kes_dashboard_live_tiles_client/TileFactory.h
+++ b/include/kes_dashboard_live_tiles_client/TileFactory.h
@@ -17,15 +17,12 @@
 
 #include "kes_dashboard_live_tiles_client/ITile.h"
 #include "kes_dashboard_live_tiles_client/ITileFactory.h"
+#include "mercury/http/http_client_interface.h"
 
 
 namespace KESDLTC {
 
 class TileFactory : public ITileFactory {
- public:  // Constructors & destructors.
-    TileFactory();
-    ~TileFactory();
-
  public:  // ITileFactory Methods.
     std::shared_ptr<ITile> create() const override;
     std::shared_ptr<ITile> create(
@@ -37,7 +34,9 @@ class TileFactory : public ITileFactory {
         const std::string& app,
         const std::string& openUrl,
         const std::string& fallbackUrl,
-        const std::string& coverPath = "") const override;
+        const std::string& coverPath = "",
+        const std::shared_ptr<Mercury::HTTP::IHTTPClient>& httpClient =
+            nullptr) const override;
 };
 
 }  // namespace KESDLTC

--- a/include/kes_dashboard_live_tiles_client/TileManager.h
+++ b/include/kes_dashboard_live_tiles_client/TileManager.h
@@ -28,13 +28,12 @@ namespace KESDLTC {
 
 class TileManager : public ITileManager {
  public:  // Constructors & destructors.
-    TileManager(
+    explicit TileManager(
         const std::string& cacheDir = "",
-        const std::shared_ptr<KESDLTC::internal::IOnlineLoader> onlineLoader = nullptr,  // NOLINT
-        const std::shared_ptr<KESDLTC::internal::ITileCache> tileCache = nullptr,  // NOLINT
-        const std::shared_ptr<KESDLTC::internal::ITileLoader> defaultTileLoader = nullptr,  // NOLINT
-        std::shared_ptr<Mercury::Utils::IEnvironment> env = nullptr);
-    ~TileManager();
+        const std::shared_ptr<KESDLTC::internal::IOnlineLoader>& onlineLoader = nullptr,  // NOLINT
+        const std::shared_ptr<KESDLTC::internal::ITileCache>& tileCache = nullptr,  // NOLINT
+        const std::shared_ptr<KESDLTC::internal::ITileLoader>& defaultTileLoader = nullptr,  // NOLINT
+        const std::shared_ptr<Mercury::Utils::IEnvironment>& env = nullptr);
 
  public:  // ITileManager Methods.
     std::list<std::shared_ptr<ITile>> getTiles(bool cache = false) const override;  // NOLINT

--- a/include/kes_dashboard_live_tiles_client/internal/DefaultTileLoader.h
+++ b/include/kes_dashboard_live_tiles_client/internal/DefaultTileLoader.h
@@ -17,7 +17,6 @@
 #include "kes_dashboard_live_tiles_client/internal/ITileLoader.h"
 #include "kes_dashboard_live_tiles_client/ITile.h"
 #include "kes_dashboard_live_tiles_client/ITileFactory.h"
-#include "kes_dashboard_live_tiles_client/TileFactory.h"
 
 
 namespace KESDLTC {
@@ -25,16 +24,14 @@ namespace internal {
 
 class DefaultTileLoader : public ITileLoader {
  public:  // Constructors & destructors.
-    DefaultTileLoader(
-        const std::shared_ptr<ITileFactory> tileFactory =
-            std::make_shared<TileFactory>());
-    ~DefaultTileLoader();
+    explicit DefaultTileLoader(
+        const std::shared_ptr<ITileFactory>& tileFactory = nullptr);
 
  public:  // ITileLoader Methods.
     std::list<std::shared_ptr<ITile>> getTiles() override;
 
  private:  // Members.
-    const std::shared_ptr<ITileFactory> tileFactory;
+    std::shared_ptr<ITileFactory> tileFactory;
 };
 
 }  // namespace internal

--- a/include/kes_dashboard_live_tiles_client/internal/OnlineLoader.h
+++ b/include/kes_dashboard_live_tiles_client/internal/OnlineLoader.h
@@ -19,9 +19,6 @@
 #include "kes_dashboard_live_tiles_client/internal/IOnlineLoader.h"
 #include "kes_dashboard_live_tiles_client/ITile.h"
 #include "kes_dashboard_live_tiles_client/ITileFactory.h"
-#include "kes_dashboard_live_tiles_client/TileFactory.h"
-
-#include "mercury/http/http_client.h"
 #include "mercury/http/http_client_interface.h"
 
 
@@ -36,12 +33,8 @@ class OnlineLoader : public IOnlineLoader {
  public:  // Constructors & destructors.
     explicit OnlineLoader(
         const std::string& cacheDir,
-        const std::shared_ptr<Mercury::HTTP::IHTTPClient> httpClient =
-            std::make_shared<Mercury::HTTP::HTTPClient>(),
-        const std::shared_ptr<ITileFactory> tileFactory =
-            std::make_shared<TileFactory>());
-
-    ~OnlineLoader();
+        const std::shared_ptr<Mercury::HTTP::IHTTPClient>& httpClient = nullptr,
+        const std::shared_ptr<ITileFactory>& tileFactory = nullptr);
 
  public:  // ITileLoader Methods.
     /**
@@ -58,8 +51,8 @@ class OnlineLoader : public IOnlineLoader {
     // static constexpr const char* KES_DLT_URL = "https://dlt.os.kes.kessandbox.co.uk/";  // NOLINT
 
  private:  // Members.
-    const std::shared_ptr<Mercury::HTTP::IHTTPClient> httpClient;
-    const std::shared_ptr<ITileFactory> tileFactory;
+    std::shared_ptr<Mercury::HTTP::IHTTPClient> httpClient;
+    std::shared_ptr<ITileFactory> tileFactory;
     const std::string cacheDir;
 
  private:  // Constants.

--- a/include/kes_dashboard_live_tiles_client/internal/TileCache.h
+++ b/include/kes_dashboard_live_tiles_client/internal/TileCache.h
@@ -19,7 +19,6 @@
 #include "kes_dashboard_live_tiles_client/internal/ITileCache.h"
 #include "kes_dashboard_live_tiles_client/ITile.h"
 #include "kes_dashboard_live_tiles_client/ITileFactory.h"
-#include "kes_dashboard_live_tiles_client/TileFactory.h"
 
 
 namespace KESDLTC {
@@ -29,9 +28,7 @@ class TileCache : public ITileCache {
  public:  // Constructors & destructors.
     explicit TileCache(
         const std::string& cacheDir,
-        const std::shared_ptr<ITileFactory> tileFactory =
-            std::make_shared<TileFactory>());
-    ~TileCache();
+        const std::shared_ptr<ITileFactory>& tileFactory = nullptr);
 
  public:  // ITileLoader Methods.
     std::list<std::shared_ptr<ITile>> getTiles() override;
@@ -50,9 +47,9 @@ class TileCache : public ITileCache {
     std::string cachePath;
     std::shared_ptr<JSON_Value> cacheDataRoot;
     JSON_Object* cacheData;
+    std::shared_ptr<ITileFactory> tileFactory;
 
  private:  // Constants.
-    const std::shared_ptr<ITileFactory> tileFactory;
     const std::string CACHE_FILE = "cache.json";
 };
 

--- a/include/kes_moma_picks_client/IPaintingFactory.h
+++ b/include/kes_moma_picks_client/IPaintingFactory.h
@@ -17,6 +17,8 @@
 
 #include "kes_moma_picks_client/IPainting.h"
 
+#include "mercury/http/http_client_interface.h"
+
 
 namespace KESMPC {
 
@@ -34,7 +36,9 @@ class IPaintingFactory {
         const std::string& dateCreated,
         const std::string& openUrl,
         const std::string& fallbackUrl,
-        const std::string& coverPath = "") const = 0;
+        const std::string& coverPath = "",
+        const std::shared_ptr<Mercury::HTTP::IHTTPClient>& httpClient =
+            nullptr) const = 0;
 };
 
 }  // namespace KESMPC

--- a/include/kes_moma_picks_client/Painting.h
+++ b/include/kes_moma_picks_client/Painting.h
@@ -19,7 +19,6 @@
 
 #include "kes_moma_picks_client/IPainting.h"
 
-#include "mercury/http/http_client.h"
 #include "mercury/http/http_client_interface.h"
 
 
@@ -28,8 +27,7 @@ namespace KESMPC {
 class Painting : public IPainting {
  public:  // Constructors & destructors.
     explicit Painting(
-        const std::shared_ptr<Mercury::HTTP::IHTTPClient> httpClient =
-            std::make_shared<Mercury::HTTP::HTTPClient>());
+        const std::shared_ptr<Mercury::HTTP::IHTTPClient>& httpClient = nullptr);  // NOLINT
 
     Painting(
         const std::string& id,
@@ -40,10 +38,7 @@ class Painting : public IPainting {
         const std::string& openUrl,
         const std::string& fallbackUrl,
         const std::string& coverPath = "",
-        const std::shared_ptr<Mercury::HTTP::IHTTPClient> httpClient =
-            std::make_shared<Mercury::HTTP::HTTPClient>());
-
-    ~Painting();
+        const std::shared_ptr<Mercury::HTTP::IHTTPClient>& httpClient = nullptr);  // NOLINT
 
  public:  // ISerialisable Methods.
     bool initialise(JSON_Value* serialisedData) override;
@@ -71,7 +66,7 @@ class Painting : public IPainting {
     std::string dateCreated;
     std::string openUrl;
     std::string fallbackUrl;
-    const std::shared_ptr<Mercury::HTTP::IHTTPClient> httpClient;
+    std::shared_ptr<Mercury::HTTP::IHTTPClient> httpClient;
 };
 
 }  // namespace KESMPC

--- a/include/kes_moma_picks_client/PaintingFactory.h
+++ b/include/kes_moma_picks_client/PaintingFactory.h
@@ -18,14 +18,12 @@
 #include "kes_moma_picks_client/IPainting.h"
 #include "kes_moma_picks_client/IPaintingFactory.h"
 
+#include "mercury/http/http_client_interface.h"
+
 
 namespace KESMPC {
 
 class PaintingFactory : public IPaintingFactory {
- public:  // Constructors & destructors.
-    PaintingFactory();
-    ~PaintingFactory();
-
  public:  // IPaintingFactory Methods.
     std::shared_ptr<IPainting> create() const override;
     std::shared_ptr<IPainting> create(
@@ -36,7 +34,9 @@ class PaintingFactory : public IPaintingFactory {
         const std::string& dateCreated,
         const std::string& openUrl,
         const std::string& fallbackUrl,
-        const std::string& coverPath = "") const override;
+        const std::string& coverPath = "",
+        const std::shared_ptr<Mercury::HTTP::IHTTPClient>& httpClient =
+            nullptr) const override;
 };
 
 }  // namespace KESMPC

--- a/include/kes_moma_picks_client/PaintingManager.h
+++ b/include/kes_moma_picks_client/PaintingManager.h
@@ -28,13 +28,12 @@ namespace KESMPC {
 
 class PaintingManager : public IPaintingManager {
  public:  // Constructors & destructors.
-    PaintingManager(
+    explicit PaintingManager(
         const std::string& cacheDir = "",
-        const std::shared_ptr<KESMPC::internal::IOnlineLoader> onlineLoader = nullptr,  // NOLINT
-        const std::shared_ptr<KESMPC::internal::IPaintingCache> paintingCache = nullptr,  // NOLINT
-        const std::shared_ptr<KESMPC::internal::IPaintingLoader> defaultPaintingLoader = nullptr,  // NOLINT
-        const std::shared_ptr<Mercury::Utils::IEnvironment> env = nullptr);
-    ~PaintingManager();
+        const std::shared_ptr<KESMPC::internal::IOnlineLoader>& onlineLoader = nullptr,  // NOLINT
+        const std::shared_ptr<KESMPC::internal::IPaintingCache>& paintingCache = nullptr,  // NOLINT
+        const std::shared_ptr<KESMPC::internal::IPaintingLoader>& defaultPaintingLoader = nullptr,  // NOLINT
+        const std::shared_ptr<Mercury::Utils::IEnvironment>& env = nullptr);
 
  public:  // IPaintingManager Methods.
     std::list<std::shared_ptr<IPainting>> getPaintings(bool cache = false) const override;  // NOLINT

--- a/include/kes_moma_picks_client/internal/DefaultPaintingLoader.h
+++ b/include/kes_moma_picks_client/internal/DefaultPaintingLoader.h
@@ -11,13 +11,13 @@
 #ifndef INCLUDE_KES_MOMA_PICKS_CLIENT_INTERNAL_DEFAULTPAINTINGLOADER_H_
 #define INCLUDE_KES_MOMA_PICKS_CLIENT_INTERNAL_DEFAULTPAINTINGLOADER_H_
 
+
 #include <list>
 #include <memory>
 
 #include "kes_moma_picks_client/internal/IPaintingLoader.h"
 #include "kes_moma_picks_client/IPainting.h"
 #include "kes_moma_picks_client/IPaintingFactory.h"
-#include "kes_moma_picks_client/PaintingFactory.h"
 
 
 namespace KESMPC {
@@ -25,16 +25,14 @@ namespace internal {
 
 class DefaultPaintingLoader : public IPaintingLoader {
  public:  // Constructors & destructors.
-    DefaultPaintingLoader(
-        const std::shared_ptr<IPaintingFactory> paintingFactory =
-            std::make_shared<PaintingFactory>());
-    ~DefaultPaintingLoader();
+    explicit DefaultPaintingLoader(
+        const std::shared_ptr<IPaintingFactory>& paintingFactory = nullptr);
 
  public:  // IPaintingLoader Methods.
     std::list<std::shared_ptr<IPainting>> getPaintings() override;
 
  private:  // Members.
-    const std::shared_ptr<IPaintingFactory> paintingFactory;
+    std::shared_ptr<IPaintingFactory> paintingFactory;
 };
 
 }  // namespace internal

--- a/include/kes_moma_picks_client/internal/OnlineLoader.h
+++ b/include/kes_moma_picks_client/internal/OnlineLoader.h
@@ -19,9 +19,6 @@
 #include "kes_moma_picks_client/internal/IOnlineLoader.h"
 #include "kes_moma_picks_client/IPainting.h"
 #include "kes_moma_picks_client/IPaintingFactory.h"
-#include "kes_moma_picks_client/PaintingFactory.h"
-
-#include "mercury/http/http_client.h"
 #include "mercury/http/http_client_interface.h"
 
 
@@ -36,12 +33,8 @@ class OnlineLoader : public IOnlineLoader {
  public:  // Constructors & destructors.
     explicit OnlineLoader(
         const std::string& cacheDir,
-        const std::shared_ptr<Mercury::HTTP::IHTTPClient> httpClient =
-            std::make_shared<Mercury::HTTP::HTTPClient>(),
-        const std::shared_ptr<IPaintingFactory> paintingFactory =
-            std::make_shared<PaintingFactory>());
-
-    ~OnlineLoader();
+        const std::shared_ptr<Mercury::HTTP::IHTTPClient>& httpClient = nullptr,  // NOLINT
+        const std::shared_ptr<IPaintingFactory>& paintingFactory = nullptr);
 
  public:  // IPaintingLoader Methods.
     /**
@@ -58,9 +51,9 @@ class OnlineLoader : public IOnlineLoader {
     // static constexpr const char* KES_MP_URL = "https://mp.os.kes.kessandbox.co.uk/";  // NOLINT
 
  private:  // Members.
-    const std::shared_ptr<Mercury::HTTP::IHTTPClient> httpClient;
-    const std::shared_ptr<IPaintingFactory> paintingFactory;
     const std::string cacheDir;
+    std::shared_ptr<Mercury::HTTP::IHTTPClient> httpClient;
+    std::shared_ptr<IPaintingFactory> paintingFactory;
 
  private:  // Constants.
     const double QUERY_COOLDOWN = ONE_HOUR_MS;

--- a/include/kes_moma_picks_client/internal/PaintingCache.h
+++ b/include/kes_moma_picks_client/internal/PaintingCache.h
@@ -19,7 +19,6 @@
 #include "kes_moma_picks_client/internal/IPaintingCache.h"
 #include "kes_moma_picks_client/IPainting.h"
 #include "kes_moma_picks_client/IPaintingFactory.h"
-#include "kes_moma_picks_client/PaintingFactory.h"
 
 
 namespace KESMPC {
@@ -29,9 +28,7 @@ class PaintingCache : public IPaintingCache {
  public:  // Constructors & destructors.
     explicit PaintingCache(
         const std::string& cacheDir,
-        const std::shared_ptr<IPaintingFactory> paintingFactory =
-            std::make_shared<PaintingFactory>());
-    ~PaintingCache();
+        const std::shared_ptr<IPaintingFactory>& paintingFactory = nullptr);
 
  public:  // IPaintingLoader Methods.
     std::list<std::shared_ptr<IPainting>> getPaintings() override;
@@ -50,9 +47,9 @@ class PaintingCache : public IPaintingCache {
     std::string cachePath;
     std::shared_ptr<JSON_Value> cacheDataRoot;
     JSON_Object* cacheData;
+    std::shared_ptr<IPaintingFactory> paintingFactory;
 
  private:  // Constants.
-    const std::shared_ptr<IPaintingFactory> paintingFactory;
     const std::string CACHE_FILE = "cache.json";
 };
 

--- a/include/mercury/http/http_client.h
+++ b/include/mercury/http/http_client.h
@@ -39,7 +39,7 @@ class HTTPClient : public IHTTPClient {
             std::map<std::string, std::string>()) override;
     std::shared_ptr<JSON_Value> POST(
         const std::string& url,
-        const std::shared_ptr<JSON_Value> body,
+        const std::shared_ptr<JSON_Value>& body,
         const std::map<std::string, std::string>& headers =
             std::map<std::string, std::string>()) override;
     std::shared_ptr<JSON_Value> GET(

--- a/include/mercury/http/http_client_interface.h
+++ b/include/mercury/http/http_client_interface.h
@@ -64,7 +64,7 @@ class IHTTPClient {
      */
     virtual std::shared_ptr<JSON_Value> POST(
         const std::string& url,
-        const std::shared_ptr<JSON_Value> body,
+        const std::shared_ptr<JSON_Value>& body,
         const std::map<std::string, std::string>& headers =
             std::map<std::string, std::string>()) = 0;
     /**

--- a/include/mercury/kw/kw.h
+++ b/include/mercury/kw/kw.h
@@ -22,9 +22,7 @@
 #include <mutex>  // NOLINT
 #include <string>
 
-#include "mercury/http/http_client.h"
 #include "mercury/http/http_client_interface.h"
-#include "mercury/utils/Environment.h"
 #include "mercury/utils/IEnvironment.h"
 
 
@@ -42,12 +40,10 @@ class KanoWorld {
      *
      * \param client    (Optional) The HTTP client to use for requests
      */
-    KanoWorld(
+    explicit KanoWorld(
         const std::string& url = "",
-        const std::shared_ptr<Mercury::HTTP::IHTTPClient> client =
-            std::make_shared<Mercury::HTTP::HTTPClient>(),
-        const std::shared_ptr<Mercury::Utils::IEnvironment> env =
-            std::make_shared<Mercury::Utils::Environment>());
+        const std::shared_ptr<Mercury::HTTP::IHTTPClient>& client = nullptr,
+        const std::shared_ptr<Mercury::Utils::IEnvironment>& env = nullptr);
 
     /**
      * \brief Logs out the current user
@@ -184,7 +180,7 @@ class KanoWorld {
     std::string get_refresh_header(const std::string& token);
 
  public:
-    const std::string data_filename;
+    std::string data_filename;
     const std::string api_url;
 
  protected:

--- a/include/mercury/utils/Environment.h
+++ b/include/mercury/utils/Environment.h
@@ -26,10 +26,6 @@ namespace Utils {
           manipulation.
  */
 class Environment : public IEnvironment {
- public:  // Constructors & destructors.
-    Environment();
-    ~Environment();
-
  public:  // Methods.
     std::string get(const std::string& variable) const override;
 };

--- a/src/http/http_client.cpp
+++ b/src/http/http_client.cpp
@@ -113,7 +113,7 @@ std::shared_ptr<JSON_Value> HTTPClient::send_request(
 
 std::shared_ptr<JSON_Value> HTTPClient::POST(
     const std::string& url,
-    const std::shared_ptr<JSON_Value> body,
+    const std::shared_ptr<JSON_Value>& body,
     const std::map<std::string, std::string>& headers) {
     std::shared_ptr<char> body_str(
         json_serialize_to_string(body.get()),

--- a/src/kes_dashboard_live_tiles_client/DefaultTileLoader.cpp
+++ b/src/kes_dashboard_live_tiles_client/DefaultTileLoader.cpp
@@ -16,24 +16,24 @@
 #include "kes_dashboard_live_tiles_client/internal/DefaultTileLoader.h"
 #include "kes_dashboard_live_tiles_client/ITile.h"
 #include "kes_dashboard_live_tiles_client/ITileFactory.h"
+#include "kes_dashboard_live_tiles_client/TileFactory.h"
 
 using std::list;
+using std::make_shared;
 using std::shared_ptr;
 
 using KESDLTC::internal::DefaultTileLoader;
 using KESDLTC::ITile;
 using KESDLTC::ITileFactory;
+using KESDLTC::TileFactory;
 
 
 DefaultTileLoader::DefaultTileLoader(
-    const shared_ptr<ITileFactory> tileFactory):
-    tileFactory(tileFactory) {
-    // Empty constructor.
-}
-
-
-DefaultTileLoader::~DefaultTileLoader() {
-    // Empty destructor.
+    const shared_ptr<ITileFactory>& tileFactory):
+        tileFactory(tileFactory) {
+    //
+    if (this->tileFactory == nullptr)
+        this->tileFactory = make_shared<TileFactory>();
 }
 
 

--- a/src/kes_dashboard_live_tiles_client/OnlineLoader.cpp
+++ b/src/kes_dashboard_live_tiles_client/OnlineLoader.cpp
@@ -19,35 +19,39 @@
 #include "kes_dashboard_live_tiles_client/internal/OnlineLoader.h"
 #include "kes_dashboard_live_tiles_client/ITile.h"
 #include "kes_dashboard_live_tiles_client/ITileFactory.h"
+#include "kes_dashboard_live_tiles_client/TileFactory.h"
+#include "mercury/http/http_client.h"
 #include "mercury/http/http_client_interface.h"
 
 using std::cerr;
 using std::endl;
 using std::list;
+using std::make_shared;
 using std::shared_ptr;
 using std::string;
 
 using KESDLTC::internal::OnlineLoader;
 using KESDLTC::ITile;
 using KESDLTC::ITileFactory;
+using KESDLTC::TileFactory;
 
 using Mercury::HTTP::DownloadError;
 using Mercury::HTTP::IHTTPClient;
+using Mercury::HTTP::HTTPClient;
 
 
 OnlineLoader::OnlineLoader(
     const string& cacheDir,
-    const shared_ptr<IHTTPClient> httpClient,
-    const shared_ptr<ITileFactory> tileFactory):
-    cacheDir(cacheDir),
-    httpClient(httpClient),
-    tileFactory(tileFactory) {
-    // Empty constructor.
-}
-
-
-OnlineLoader::~OnlineLoader() {
-    // Empty destructor.
+    const shared_ptr<IHTTPClient>& httpClient,
+    const shared_ptr<ITileFactory>& tileFactory):
+        cacheDir(cacheDir),
+        httpClient(httpClient),
+        tileFactory(tileFactory) {
+    //
+    if (this->httpClient == nullptr)
+        this->httpClient = make_shared<HTTPClient>();
+    if (this->tileFactory == nullptr)
+        this->tileFactory = make_shared<TileFactory>();
 }
 
 

--- a/src/kes_dashboard_live_tiles_client/Tile.cpp
+++ b/src/kes_dashboard_live_tiles_client/Tile.cpp
@@ -19,40 +19,40 @@
 
 #include "kes_dashboard_live_tiles_client/Tile.h"
 #include "mercury/http/http_client.h"
+#include "mercury/http/http_client_interface.h"
 #include "mercury/utils/Filesystem.h"
 #include "mercury/utils/String.h"
 
 using std::cerr;
 using std::endl;
+using std::make_shared;
 using std::shared_ptr;
 using std::string;
 
 using KESDLTC::Tile;
 
 using Mercury::HTTP::IHTTPClient;
+using Mercury::HTTP::HTTPClient;
 
 
-Tile::Tile(const shared_ptr<IHTTPClient> httpClient):
+Tile::Tile(const shared_ptr<IHTTPClient>& httpClient):
     Tile("", "", "", "", "", "", "", "", "", httpClient) {
     // Empty constructor.
 }
 
 
-Tile::Tile(const string& id, const string& cover,
-           const string& title, const string& description,
-           const string& username, const string& app,
-           const string& openUrl, const string& fallbackUrl,
-           const string& coverPath, const shared_ptr<IHTTPClient> httpClient):
-    id(id), cover(cover), title(title),
-    description(description), username(username), app(app),
-    openUrl(openUrl), fallbackUrl(fallbackUrl), coverPath(coverPath),
-    httpClient(httpClient) {
-    // Empty constructor.
-}
-
-
-Tile::~Tile() {
-    // Empty destructor.
+Tile::Tile(
+    const string& id, const string& cover, const string& title,
+    const string& description, const string& username, const string& app,
+    const string& openUrl, const string& fallbackUrl, const string& coverPath,
+    const shared_ptr<IHTTPClient>& httpClient):
+        id(id), cover(cover), title(title),
+        description(description), username(username), app(app),
+        openUrl(openUrl), fallbackUrl(fallbackUrl), coverPath(coverPath),
+        httpClient(httpClient) {
+    //
+    if (this->httpClient == nullptr)
+        this->httpClient = make_shared<HTTPClient>();
 }
 
 

--- a/src/kes_dashboard_live_tiles_client/TileCache.cpp
+++ b/src/kes_dashboard_live_tiles_client/TileCache.cpp
@@ -19,12 +19,14 @@
 #include "kes_dashboard_live_tiles_client/internal/TileCache.h"
 #include "kes_dashboard_live_tiles_client/ITile.h"
 #include "kes_dashboard_live_tiles_client/ITileFactory.h"
+#include "kes_dashboard_live_tiles_client/TileFactory.h"
 #include "mercury/utils/Filesystem.h"
 #include "mercury/utils/Time.h"
 
 using std::cerr;
 using std::endl;
 using std::list;
+using std::make_shared;
 using std::shared_ptr;
 using std::string;
 
@@ -32,23 +34,22 @@ using KESDLTC::internal::CorruptedCacheException;
 using KESDLTC::internal::TileCache;
 using KESDLTC::ITile;
 using KESDLTC::ITileFactory;
+using KESDLTC::TileFactory;
 
 
 TileCache::TileCache(
     const string& cacheDir,
-    const shared_ptr<ITileFactory> tileFactory):
-    cacheDir(cacheDir),
-    tileFactory(tileFactory),
-    cacheDataRoot(nullptr),
-    cacheData(nullptr) {
+    const shared_ptr<ITileFactory>& tileFactory):
+        cacheDir(cacheDir),
+        tileFactory(tileFactory),
+        cacheDataRoot(nullptr),
+        cacheData(nullptr) {
+    //
     this->cachePath = this->cacheDir + "/" + this->CACHE_FILE;
+    if (this->tileFactory == nullptr)
+        this->tileFactory = make_shared<TileFactory>();
 
     this->load();
-}
-
-
-TileCache::~TileCache() {
-    // Empty destructor.
 }
 
 
@@ -62,7 +63,7 @@ void TileCache::load() {
 void TileCache::setCacheData() {
     if (this->cacheDataRoot != nullptr &&
         this->cacheDataRoot.get() != nullptr) {
-        // NOLINT
+        //
         this->cacheData = json_value_get_object(this->cacheDataRoot.get());
     } else {
         this->cacheData = nullptr;

--- a/src/kes_dashboard_live_tiles_client/TileFactory.cpp
+++ b/src/kes_dashboard_live_tiles_client/TileFactory.cpp
@@ -14,6 +14,8 @@
 #include "kes_dashboard_live_tiles_client/ITile.h"
 #include "kes_dashboard_live_tiles_client/Tile.h"
 #include "kes_dashboard_live_tiles_client/TileFactory.h"
+#include "mercury/http/http_client.h"
+#include "mercury/http/http_client_interface.h"
 
 using std::make_shared;
 using std::shared_ptr;
@@ -23,15 +25,8 @@ using KESDLTC::ITile;
 using KESDLTC::Tile;
 using KESDLTC::TileFactory;
 
-
-TileFactory::TileFactory() {
-    // Emptry constructor.
-}
-
-
-TileFactory::~TileFactory() {
-    // Empty destructor.
-}
+using Mercury::HTTP::IHTTPClient;
+using Mercury::HTTP::HTTPClient;
 
 
 shared_ptr<ITile> TileFactory::create() const {
@@ -40,12 +35,12 @@ shared_ptr<ITile> TileFactory::create() const {
 
 
 shared_ptr<ITile> TileFactory::create(
-        const string& id, const string& cover,
-        const string& title, const string& description,
-        const string& username, const string& app,
+        const string& id, const string& cover, const string& title,
+        const string& description, const string& username, const string& app,
         const string& openUrl, const string& fallbackUrl,
-        const string& coverPath) const {
+        const string& coverPath,
+        const shared_ptr<IHTTPClient>& httpClient) const {
     return make_shared<Tile>(
         id, cover, title, description, username, app, openUrl, fallbackUrl,
-        coverPath);
+        coverPath, httpClient);
 }

--- a/src/kes_dashboard_live_tiles_client/TileManager.cpp
+++ b/src/kes_dashboard_live_tiles_client/TileManager.cpp
@@ -42,6 +42,7 @@ using KESDLTC::internal::OnlineLoader;
 using KESDLTC::internal::TileCache;
 using KESDLTC::ITile;
 using KESDLTC::TileManager;
+
 using Mercury::Utils::IEnvironment;
 using Mercury::Utils::Environment;
 
@@ -49,30 +50,24 @@ using Mercury::Utils::Environment;
 
 TileManager::TileManager(
     const string& cacheDir,
-    const shared_ptr<IOnlineLoader> onlineLoader,
-    const shared_ptr<ITileCache> tileCache,
-    const shared_ptr<ITileLoader> defaultTileLoader,
-    shared_ptr<IEnvironment> env):
-    cacheDir(cacheDir),
-    onlineLoader(onlineLoader),
-    tileCache(tileCache),
-    defaultTileLoader(defaultTileLoader) {
-    // NOLINT
-    if (env == nullptr)
-        env = make_shared<Environment>();
+    const shared_ptr<IOnlineLoader>& onlineLoader,
+    const shared_ptr<ITileCache>& tileCache,
+    const shared_ptr<ITileLoader>& defaultTileLoader,
+    const shared_ptr<IEnvironment>& env):
+        cacheDir(cacheDir),
+        onlineLoader(onlineLoader),
+        tileCache(tileCache),
+        defaultTileLoader(defaultTileLoader) {
+    //
+    auto environ = (env == nullptr) ? make_shared<Environment>() : env;
     if (this->cacheDir == "")
-        this->cacheDir = env->get("HOME") + "/" + this->CACHE_DIRNAME;
+        this->cacheDir = environ->get("HOME") + "/" + this->CACHE_DIRNAME;
     if (this->onlineLoader == nullptr)
         this->onlineLoader = make_shared<OnlineLoader>(this->cacheDir);
     if (this->tileCache == nullptr)
         this->tileCache = make_shared<TileCache>(this->cacheDir);
     if (this->defaultTileLoader == nullptr)
         this->defaultTileLoader = make_shared<DefaultTileLoader>();
-}
-
-
-TileManager::~TileManager() {
-    // Empty destructor.
 }
 
 

--- a/src/kes_moma_picks_client/DefaultPaintingLoader.cpp
+++ b/src/kes_moma_picks_client/DefaultPaintingLoader.cpp
@@ -16,24 +16,24 @@
 #include "kes_moma_picks_client/internal/DefaultPaintingLoader.h"
 #include "kes_moma_picks_client/IPainting.h"
 #include "kes_moma_picks_client/IPaintingFactory.h"
+#include "kes_moma_picks_client/PaintingFactory.h"
 
 using std::list;
+using std::make_shared;
 using std::shared_ptr;
 
 using KESMPC::internal::DefaultPaintingLoader;
 using KESMPC::IPainting;
 using KESMPC::IPaintingFactory;
+using KESMPC::PaintingFactory;
 
 
 DefaultPaintingLoader::DefaultPaintingLoader(
-    const shared_ptr<IPaintingFactory> paintingFactory):
-    paintingFactory(paintingFactory) {
-    // Empty constructor.
-}
-
-
-DefaultPaintingLoader::~DefaultPaintingLoader() {
-    // Empty destructor.
+    const shared_ptr<IPaintingFactory>& paintingFactory):
+        paintingFactory(paintingFactory) {
+    //
+    if (this->paintingFactory == nullptr)
+        this->paintingFactory = make_shared<PaintingFactory>();
 }
 
 

--- a/src/kes_moma_picks_client/OnlineLoader.cpp
+++ b/src/kes_moma_picks_client/OnlineLoader.cpp
@@ -19,35 +19,39 @@
 #include "kes_moma_picks_client/internal/OnlineLoader.h"
 #include "kes_moma_picks_client/IPainting.h"
 #include "kes_moma_picks_client/IPaintingFactory.h"
+#include "kes_moma_picks_client/PaintingFactory.h"
+#include "mercury/http/http_client.h"
 #include "mercury/http/http_client_interface.h"
 
 using std::cerr;
 using std::endl;
 using std::list;
+using std::make_shared;
 using std::shared_ptr;
 using std::string;
 
 using KESMPC::internal::OnlineLoader;
 using KESMPC::IPainting;
 using KESMPC::IPaintingFactory;
+using KESMPC::PaintingFactory;
 
 using Mercury::HTTP::DownloadError;
+using Mercury::HTTP::HTTPClient;
 using Mercury::HTTP::IHTTPClient;
 
 
 OnlineLoader::OnlineLoader(
     const string& cacheDir,
-    const shared_ptr<IHTTPClient> httpClient,
-    const shared_ptr<IPaintingFactory> paintingFactory):
-    cacheDir(cacheDir),
-    httpClient(httpClient),
-    paintingFactory(paintingFactory) {
-    // Empty constructor.
-}
-
-
-OnlineLoader::~OnlineLoader() {
-    // Empty destructor.
+    const shared_ptr<IHTTPClient>& httpClient,
+    const shared_ptr<IPaintingFactory>& paintingFactory):
+        cacheDir(cacheDir),
+        httpClient(httpClient),
+        paintingFactory(paintingFactory) {
+    //
+    if (this->httpClient == nullptr)
+        this->httpClient = make_shared<HTTPClient>();
+    if (this->paintingFactory == nullptr)
+        this->paintingFactory = make_shared<PaintingFactory>();
 }
 
 

--- a/src/kes_moma_picks_client/Painting.cpp
+++ b/src/kes_moma_picks_client/Painting.cpp
@@ -19,39 +19,39 @@
 
 #include "kes_moma_picks_client/Painting.h"
 #include "mercury/http/http_client.h"
+#include "mercury/http/http_client_interface.h"
 #include "mercury/utils/Filesystem.h"
 #include "mercury/utils/String.h"
 
 using std::cerr;
 using std::endl;
+using std::make_shared;
 using std::shared_ptr;
 using std::string;
 
 using KESMPC::Painting;
 
+using Mercury::HTTP::HTTPClient;
 using Mercury::HTTP::IHTTPClient;
 
 
-Painting::Painting(const shared_ptr<IHTTPClient> httpClient):
+Painting::Painting(const shared_ptr<IHTTPClient>& httpClient):
     Painting("", "", "", "", "", "", "", "", httpClient) {
     // Empty constructor.
 }
 
 
-Painting::Painting(const string& id, const string& cover,
-        const string& title, const string& username,
-        const string& dateCreated, const string& openUrl,
-        const string& fallbackUrl, const string& coverPath,
-        const shared_ptr<IHTTPClient> httpClient):
-    id(id), cover(cover), title(title), username(username),
-    dateCreated(dateCreated), openUrl(openUrl), fallbackUrl(fallbackUrl),
-    coverPath(coverPath), httpClient(httpClient) {
-    // Empty constructor.
-}
-
-
-Painting::~Painting() {
-    // Empty destructor.
+Painting::Painting(
+    const string& id, const string& cover, const string& title,
+    const string& username, const string& dateCreated,
+    const string& openUrl, const string& fallbackUrl,
+    const string& coverPath, const shared_ptr<IHTTPClient>& httpClient):
+        id(id), cover(cover), title(title), username(username),
+        dateCreated(dateCreated), openUrl(openUrl), fallbackUrl(fallbackUrl),
+        coverPath(coverPath), httpClient(httpClient) {
+    //
+    if (this->httpClient == nullptr)
+        this->httpClient = make_shared<HTTPClient>();
 }
 
 

--- a/src/kes_moma_picks_client/PaintingCache.cpp
+++ b/src/kes_moma_picks_client/PaintingCache.cpp
@@ -19,12 +19,14 @@
 #include "kes_moma_picks_client/internal/PaintingCache.h"
 #include "kes_moma_picks_client/IPainting.h"
 #include "kes_moma_picks_client/IPaintingFactory.h"
+#include "kes_moma_picks_client/PaintingFactory.h"
 #include "mercury/utils/Filesystem.h"
 #include "mercury/utils/Time.h"
 
 using std::cerr;
 using std::endl;
 using std::list;
+using std::make_shared;
 using std::shared_ptr;
 using std::string;
 
@@ -32,23 +34,21 @@ using KESMPC::internal::CorruptedCacheException;
 using KESMPC::internal::PaintingCache;
 using KESMPC::IPainting;
 using KESMPC::IPaintingFactory;
+using KESMPC::PaintingFactory;
 
 
 PaintingCache::PaintingCache(
     const string& cacheDir,
-    const shared_ptr<IPaintingFactory> paintingFactory):
-    cacheDir(cacheDir),
-    paintingFactory(paintingFactory),
-    cacheDataRoot(nullptr),
-    cacheData(nullptr) {
+    const shared_ptr<IPaintingFactory>& paintingFactory):
+        cacheDir(cacheDir),
+        paintingFactory(paintingFactory),
+        cacheDataRoot(nullptr),
+        cacheData(nullptr) {
+    //
     this->cachePath = this->cacheDir + "/" + this->CACHE_FILE;
-
+    if (this->paintingFactory == nullptr)
+        this->paintingFactory = make_shared<PaintingFactory>();
     this->load();
-}
-
-
-PaintingCache::~PaintingCache() {
-    // Empty destructor.
 }
 
 

--- a/src/kes_moma_picks_client/PaintingFactory.cpp
+++ b/src/kes_moma_picks_client/PaintingFactory.cpp
@@ -15,6 +15,8 @@
 #include "kes_moma_picks_client/Painting.h"
 #include "kes_moma_picks_client/PaintingFactory.h"
 
+#include "mercury/http/http_client_interface.h"
+
 using std::make_shared;
 using std::shared_ptr;
 using std::string;
@@ -23,15 +25,7 @@ using KESMPC::IPainting;
 using KESMPC::Painting;
 using KESMPC::PaintingFactory;
 
-
-PaintingFactory::PaintingFactory() {
-    // Emptry constructor.
-}
-
-
-PaintingFactory::~PaintingFactory() {
-    // Empty destructor.
-}
+using Mercury::HTTP::IHTTPClient;
 
 
 shared_ptr<IPainting> PaintingFactory::create() const {
@@ -47,7 +41,8 @@ shared_ptr<IPainting> PaintingFactory::create(
         const string& dateCreated,
         const string& openUrl,
         const string& fallbackUrl,
-        const string& coverPath) const {
+        const string& coverPath,
+        const shared_ptr<IHTTPClient>& httpClient) const {
     return make_shared<Painting>(
         id,
         cover,
@@ -56,5 +51,6 @@ shared_ptr<IPainting> PaintingFactory::create(
         dateCreated,
         openUrl,
         fallbackUrl,
-        coverPath);
+        coverPath,
+        httpClient);
 }

--- a/src/kes_moma_picks_client/PaintingManager.cpp
+++ b/src/kes_moma_picks_client/PaintingManager.cpp
@@ -48,30 +48,24 @@ using Mercury::Utils::Environment;
 
 PaintingManager::PaintingManager(
     const string& cacheDir,
-    const shared_ptr<IOnlineLoader> onlineLoader,
-    const shared_ptr<IPaintingCache> paintingCache,
-    const shared_ptr<IPaintingLoader> defaultPaintingLoader,
-    shared_ptr<IEnvironment> env):
-    cacheDir(cacheDir),
-    onlineLoader(onlineLoader),
-    paintingCache(paintingCache),
-    defaultPaintingLoader(defaultPaintingLoader) {
-    // NOLINT
-    if (env == nullptr)
-        env = make_shared<Environment>();
+    const shared_ptr<IOnlineLoader>& onlineLoader,
+    const shared_ptr<IPaintingCache>& paintingCache,
+    const shared_ptr<IPaintingLoader>& defaultPaintingLoader,
+    const shared_ptr<IEnvironment>& env):
+        cacheDir(cacheDir),
+        onlineLoader(onlineLoader),
+        paintingCache(paintingCache),
+        defaultPaintingLoader(defaultPaintingLoader) {
+    //
+    auto environ = (env == nullptr) ? make_shared<Environment>() : env;
     if (this->cacheDir == "")
-        this->cacheDir = env->get("HOME") + "/" + this->CACHE_DIRNAME;
+        this->cacheDir = environ->get("HOME") + "/" + this->CACHE_DIRNAME;
     if (this->onlineLoader == nullptr)
         this->onlineLoader = make_shared<OnlineLoader>(this->cacheDir);
     if (this->paintingCache == nullptr)
         this->paintingCache = make_shared<PaintingCache>(this->cacheDir);
     if (this->defaultPaintingLoader == nullptr)
         this->defaultPaintingLoader = make_shared<DefaultPaintingLoader>();
-}
-
-
-PaintingManager::~PaintingManager() {
-    // Empty destructor.
 }
 
 

--- a/src/kw/kw.cpp
+++ b/src/kw/kw.cpp
@@ -20,9 +20,11 @@
 #include <string>
 #include <utility>
 
+#include "mercury/http/http_client.h"
 #include "mercury/http/http_client_interface.h"
 #include "mercury/kw/APIConfig.h"
 #include "mercury/kw/kw.h"
+#include "mercury/utils/Environment.h"
 #include "mercury/utils/IEnvironment.h"
 #include "mercury/utils/Time.h"
 
@@ -35,29 +37,37 @@ using std::endl;
 using std::exception;
 using std::map;
 using std::make_pair;
+using std::make_shared;
 using std::shared_ptr;
 using std::string;
 
 using Mercury::HTTP::IHTTPClient;
+using Mercury::HTTP::HTTPClient;
 using Mercury::HTTP::HTTPRequestFailedError;
 using Mercury::HTTP::SessionInitError;
-
 using Mercury::KanoWorld::APIConfig;
 using Mercury::KanoWorld::KanoWorld;
-
+using Mercury::Utils::Environment;
 using Mercury::Utils::IEnvironment;
 
 
 KanoWorld::KanoWorld(
     const string& url,
-    const shared_ptr<IHTTPClient> client,
-    const shared_ptr<IEnvironment> env):
+    const shared_ptr<IHTTPClient>& client,
+    const shared_ptr<IEnvironment>& env):
         http_client(client),
-        data_filename(env->get("HOME") + "/.mercury_kw.json"),
+        data_filename(""),
         token(""),
         api_url(init_api_url(url)),
         expiration_date(0),
         is_verified_cache(false) {
+    //
+    if (this->http_client == nullptr)
+        this->http_client = make_shared<HTTPClient>();
+
+    auto environ = (env == nullptr) ? make_shared<Environment>() : env;
+    this->data_filename = environ->get("HOME") + "/.mercury_kw.json";
+
     load_data();
 }
 

--- a/src/utils/Environment.cpp
+++ b/src/utils/Environment.cpp
@@ -9,7 +9,6 @@
 
 
 #include <cstdlib>
-
 #include <string>
 
 #include "mercury/utils/Environment.h"
@@ -17,16 +16,6 @@
 using std::string;
 
 using Mercury::Utils::Environment;
-
-
-Environment::Environment() {
-    // Empty constructor.
-}
-
-
-Environment::~Environment() {
-    // Empty destructor.
-}
 
 
 std::string Environment::get(const std::string& variable) const {

--- a/test/mocks/kes_dlt_cli/MockTileFactory.h
+++ b/test/mocks/kes_dlt_cli/MockTileFactory.h
@@ -18,6 +18,7 @@
 
 #include "kes_dashboard_live_tiles_client/ITile.h"
 #include "kes_dashboard_live_tiles_client/ITileFactory.h"
+#include "mercury/http/http_client_interface.h"
 
 
 namespace KESDLTC {
@@ -41,14 +42,16 @@ class MockTileFactory : public KESDLTC::ITileFactory {
         const std::string& app,
         const std::string& openUrl,
         const std::string& fallbackUrl,
-        const std::string& coverPath = "") const {
-        // NOLINT
+        const std::string& coverPath = "",
+        const std::shared_ptr<Mercury::HTTP::IHTTPClient>& httpClient =
+            nullptr) const {
+        //
         return this->create_impl(
-            id, cover, title, description, username, app,
-            openUrl, fallbackUrl, coverPath);
+            id, cover, title, description, username, app, openUrl, fallbackUrl,
+            coverPath, httpClient);
     }
 
-    MOCK_CONST_METHOD9(
+    MOCK_CONST_METHOD10(
         create_impl,
         std::shared_ptr<ITile>(
             const std::string& id,
@@ -59,7 +62,8 @@ class MockTileFactory : public KESDLTC::ITileFactory {
             const std::string& app,
             const std::string& openUrl,
             const std::string& fallbackUrl,
-            const std::string& coverPath));
+            const std::string& coverPath,
+            const std::shared_ptr<Mercury::HTTP::IHTTPClient>& httpClient));
 };
 
 }  // namespace test

--- a/test/mocks/kes_mp_cli/MockPaintingFactory.h
+++ b/test/mocks/kes_mp_cli/MockPaintingFactory.h
@@ -19,6 +19,8 @@
 #include "kes_moma_picks_client/IPainting.h"
 #include "kes_moma_picks_client/IPaintingFactory.h"
 
+#include "mercury/http/http_client_interface.h"
+
 
 namespace KESMPC {
 namespace test {
@@ -40,8 +42,10 @@ class MockPaintingFactory : public KESMPC::IPaintingFactory {
         const std::string& dateCreated,
         const std::string& openUrl,
         const std::string& fallbackUrl,
-        const std::string& coverPath = "") const {
-        // NOLINT
+        const std::string& coverPath = "",
+        const std::shared_ptr<Mercury::HTTP::IHTTPClient>& httpClient =
+            nullptr) const {
+        //
         return this->create_impl(
             id,
             cover,
@@ -50,10 +54,11 @@ class MockPaintingFactory : public KESMPC::IPaintingFactory {
             dateCreated,
             openUrl,
             fallbackUrl,
-            coverPath);
+            coverPath,
+            httpClient);
     }
 
-    MOCK_CONST_METHOD8(
+    MOCK_CONST_METHOD9(
         create_impl,
         std::shared_ptr<IPainting>(
             const std::string& id,
@@ -63,10 +68,12 @@ class MockPaintingFactory : public KESMPC::IPaintingFactory {
             const std::string& dateCreated,
             const std::string& openUrl,
             const std::string& fallbackUrl,
-            const std::string& coverPath));
+            const std::string& coverPath,
+            const std::shared_ptr<Mercury::HTTP::IHTTPClient>& httpClient));
 };
 
 }  // namespace test
 }  // namespace KESMPC
+
 
 #endif  // TEST_MOCKS_KES_MP_CLI_MOCKPAINTINGFACTORY_H_

--- a/test/mocks/mock_http_client.h
+++ b/test/mocks/mock_http_client.h
@@ -89,7 +89,7 @@ class MockHTTPClient : public Mercury::HTTP::IHTTPClient {
      */
     virtual std::shared_ptr<JSON_Value> POST(
         const std::string& url,
-        std::shared_ptr<JSON_Value> body,
+        const std::shared_ptr<JSON_Value>& body,
         const std::map<std::string, std::string>& headers =
             std::map<std::string, std::string>()) {
         return this->POST_impl(url, body, headers);
@@ -145,7 +145,7 @@ class MockHTTPClient : public Mercury::HTTP::IHTTPClient {
         POST_impl,
         std::shared_ptr<JSON_Value>(
             const std::string& url,
-            std::shared_ptr<JSON_Value> body,
+            const std::shared_ptr<JSON_Value>& body,
             const std::map<std::string, std::string>& headers));
     /**
      * \brief Internal mocked version of the GET to account for optional


### PR DESCRIPTION
Functions which contain constant reference optional arguments must be
wary when assigning default values to them. Object construction in
headers here are bound to the scope of the function and will be
deallocated at the end. Our code suffered heavily from using this
pattern to facilite dependency injection that enabled testing.

For further reading see the following:
https://stackoverflow.com/questions/12554619/what-is-the-lifetime-of-a-default-argument-temporary-bound-to-a-reference-parame

cc @Ealdwulf 