### PR TITLE
Repaired Conan packaging for dynamic and static Windows libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,9 +45,4 @@ if (CMAKE_BUILD_TYPE MATCHES Debug)
     endif ()
 endif (CMAKE_BUILD_TYPE MATCHES Debug)
 
-# For some reason this is mandatory on Windows, or above if() fails
-if (WIN32)
-    add_subdirectory(test)
-endif()
-
 enable_testing()

--- a/conan-platforms/conan-profile-Windows-VS2019-x86.info
+++ b/conan-platforms/conan-profile-Windows-VS2019-x86.info
@@ -1,11 +1,10 @@
 [settings]
 os=Windows
 os_build=Windows
-arch=x86_64
-arch_build=x86_64
+arch=x86
+arch_build=x86
 compiler=Visual Studio
 compiler.version=16
-#compiler.libcxx=libstdc++11
 build_type=Release
 [options]
 [build_requires]

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,3 +1,4 @@
+import os
 from conans import ConanFile, CMake, tools
 
 
@@ -38,20 +39,26 @@ class MercuryConan(ConanFile):
             defs={
                 "BUILD_PYTHON": "OFF",
                 "BUILD_PYTHON2": "OFF",
+                "BUILD_CSHARP": "OFF"
             }
         )
         cmake.build()
 
     def package(self):
         self.copy("*.h", dst="include", src="include")
-        self.copy("*mercury.lib", dst="lib", keep_path=False)
-        self.copy("*.dll", dst="bin", keep_path=False)
 
         if self.options.shared:
             self.copy("*.so", dst="lib", keep_path=False)
             self.copy("*.dylib", dst="lib", keep_path=False)
+            self.copy("*.dll", dst="bin", keep_path=False)
+            self.copy("*mercury.lib", dst="lib", keep_path=False)
         else:
             self.copy("*.a", dst="lib", keep_path=False)
+            self.copy("*static.lib", dst="lib", keep_path=False)
 
     def package_info(self):
-        self.cpp_info.libs = ["mercury"]
+        # Only on Windows, for now, the static library is called mercury_static.lib
+        if not self.options.shared and os.name == 'nt':
+            self.cpp_info.libs = ["mercury_static"]
+        else:
+            self.cpp_info.libs = ["mercury"]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,9 +54,17 @@ endif()
 set_target_properties(mercury_shared
     PROPERTIES OUTPUT_NAME mercury
 )
-set_target_properties(mercury_static
-    PROPERTIES OUTPUT_NAME mercury
-)
+# For now, under Windows we rename the static library since the import
+# library for the DLL will have the same name and overwrite it.
+if (MSVC)
+    set_target_properties(mercury_static
+        PROPERTIES OUTPUT_NAME mercury_static
+    )
+else()
+    set_target_properties(mercury_static
+        PROPERTIES OUTPUT_NAME mercury
+    )
+endif()
 set_property(TARGET mercury_static PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 target_include_directories(mercury_shared PUBLIC

--- a/src/swig/CMakeLists.txt
+++ b/src/swig/CMakeLists.txt
@@ -5,12 +5,13 @@ include(${SWIG_USE_FILE})
 # Add subdirectories for each language if desired
 option(BUILD_PYTHON "Build Python 3 SWIG module" ON)
 option(BUILD_PYTHON2 "Build Python 2 SWIG module" ON)
+option(BUILD_CSHARP "Build C sharp SWIG module" OFF)
 
-
-# Do not build Python bindings on Windows for now
+# Do not build Python and C sharp bindings on Windows for now
 if (MSVC)
-   set(BUILD_PYTHON OFF)
-   set(BUILD_PYTHON2 OFF)
+    set(BUILD_PYTHON OFF)
+    set(BUILD_PYTHON2 OFF)
+    set(BUILD_CSHARP OFF)
 endif()
 
 if (BUILD_PYTHON)
@@ -21,7 +22,6 @@ if (BUILD_PYTHON2)
     add_subdirectory(python2)
 endif()
 
-# On Windows, build the C# bindings
-if (MSVC)
+if (BUILD_CSHARP)
    add_subdirectory(csharp)
 endif()

--- a/windows-build.bat
+++ b/windows-build.bat
@@ -20,18 +20,18 @@ conan remote update dev-server http://dev.kano.me:9300
 
 cd build\release
 
-conan install -r dev-server --build=missing --profile=..\..\conan-platforms\conan-profile-Windows-devstudio-2019.info ..\..
-conan install --build=missing --profile=..\..\conan-platforms\conan-profile-Windows-devstudio-2019.info ..\..
+conan install -r dev-server --build=missing --profile=..\..\conan-platforms\conan-profile-Windows-VS2019-x86.info ..\..
+conan install --build=missing --profile=..\..\conan-platforms\conan-profile-Windows-VS2019-x86.info ..\..
 
 cmake -DCMAKE_BUILD_TYPE=Release ..\..
 
 @echo ">>> BUILDING MERCURY SHARED" >> build.log
-msbuild.exe -p:Configuration=Release src\mercury_shared.vcxproj
+msbuild.exe -p:Configuration=Release -p:Platform=x86 src\mercury_shared.vcxproj
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 @echo ">>> BUILDING MERCURY STATIC" >> build.log
-msbuild.exe -p:Configuration=Release src\mercury_static.vcxproj
+msbuild.exe -p:Configuration=Release -p:Platform=x86 src\mercury_static.vcxproj
 if %errorlevel% neq 0 exit /b %errorlevel%
 
-@echo ">>> BUILDING C SHARP BINDINGS" >> build.log
-msbuild.exe -p:Configuration=Release src\swig\csharp\mercury_csharp.vcxproj
+:: @echo ">>> BUILDING C SHARP BINDINGS" >> build.log
+:: msbuild.exe -p:Configuration=Release src\swig\csharp\mercury_csharp.vcxproj


### PR DESCRIPTION
This is not a complete or proper approach yet but gets us what we
need for now. It would be good to adopt library naming conventions
on Windows from Poco and separate out static and dynamic packages
and compilation.