### PR TITLE
fix(windows): add store required linker flags

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,9 @@ if (MSVC)
         STATIC_DEFINE mercury_shared__BUILT_AS_STATIC
     )
     add_definitions(-DPOCO_STATIC)
+    target_link_options(mercury_shared PUBLIC
+        /APPCONTAINER /SAFESEH /DYNAMICBASE /NXCOMPAT
+    )
 endif()
 
 set_target_properties(mercury_shared


### PR DESCRIPTION
In order to be submitted to the store, all `.dll`s require the
`/APPCONTAINER`, `/SAFESEH`, `DYNAMICBASE` and `NXCOMPAT` linker flags
set so explicitly specify these.